### PR TITLE
Removing readonly property from the username on the login form

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -30,8 +30,7 @@ $(document).ready(function(){
 				.val('')
 				.get(0).focus();
 			$('#user')
-				.val(user)
-				.prop('readonly', true);
+				.val(user);
 		}
 	}
 });


### PR DESCRIPTION
This is to avoid what's described in https://github.com/owncloud/oauth2/issues/74: auto-filling the username on the login form in LDAP UUID setups prevented the user (from the Desktop client) to re-login.

Not an optimal solution from an UX POV, but at least does not completely breaks the re-authentication from on the Desktop client.