### PR TITLE
Move all hardcoded expiration deltas to constants

### DIFF
--- a/lib/Controller/OAuthApiController.php
+++ b/lib/Controller/OAuthApiController.php
@@ -199,7 +199,7 @@ class OAuthApiController extends ApiController {
 			[
 				'access_token' => $accessToken->getToken(),
 				'token_type' => 'Bearer',
-				'expires_in' => 3600,
+				'expires_in' => AccessToken::EXPIRATION_TIME,
 				'refresh_token' => $refreshToken->getToken(),
 				'user_id' => $userId,
 				'message_url' => $this->urlGenerator->linkToRouteAbsolute($this->appName . '.page.authorizationSuccessful')

--- a/lib/Db/AccessToken.php
+++ b/lib/Db/AccessToken.php
@@ -33,6 +33,8 @@ use OCP\AppFramework\Db\Entity;
  */
 class AccessToken extends Entity {
 
+	const EXPIRATION_TIME = 3600;
+
 	protected $token;
 	protected $clientId;
 	protected $userId;
@@ -50,10 +52,10 @@ class AccessToken extends Entity {
 	}
 
 	/**
-	 * Resets the expiry time to 1 hour from now.
+	 * Resets the expiry time to EXPIRATION_TIME seconds from now.
 	 */
 	public function resetExpires() {
-		$this->setExpires(time() + 3600);
+		$this->setExpires(time() + self::EXPIRATION_TIME);
 	}
 
 	/**

--- a/lib/Db/AuthorizationCode.php
+++ b/lib/Db/AuthorizationCode.php
@@ -33,6 +33,8 @@ use OCP\AppFramework\Db\Entity;
  */
 class AuthorizationCode extends Entity {
 
+	const EXPIRATION_TIME = 600;
+
 	protected $code;
 	protected $clientId;
 	protected $userId;
@@ -50,10 +52,10 @@ class AuthorizationCode extends Entity {
 	}
 
 	/**
-	 * Resets the expiry time to 10 minutes from now.
+	 * Resets the expiry time to EXPIRATION_TIME seconds from now.
 	 */
 	public function resetExpires() {
-		$this->setExpires(time() + 600);
+		$this->setExpires(time() + self::EXPIRATION_TIME);
 	}
 
 	/**

--- a/tests/Unit/Controller/OAuthApiControllerTest.php
+++ b/tests/Unit/Controller/OAuthApiControllerTest.php
@@ -267,7 +267,7 @@ class OAuthApiControllerTest extends PHPUnit_Framework_TestCase {
 		$this->assertNotEmpty($json->token_type);
 		$this->assertEquals('Bearer', $json->token_type);
 		$this->assertNotEmpty($json->expires_in);
-		$this->assertEquals(3600, $json->expires_in);
+		$this->assertEquals(AccessToken::EXPIRATION_TIME, $json->expires_in);
 		$this->assertNotEmpty($json->refresh_token);
 		$this->assertEquals(64, strlen($json->refresh_token));
 		$this->assertNotEmpty($json->user_id);
@@ -346,7 +346,7 @@ class OAuthApiControllerTest extends PHPUnit_Framework_TestCase {
 		$this->assertNotEmpty($json->token_type);
 		$this->assertEquals('Bearer', $json->token_type);
 		$this->assertNotEmpty($json->expires_in);
-		$this->assertEquals(3600, $json->expires_in);
+		$this->assertEquals(AccessToken::EXPIRATION_TIME, $json->expires_in);
 		$this->assertNotEmpty($json->refresh_token);
 		$this->assertEquals(64, strlen($json->refresh_token));
 		$this->assertNotEmpty($json->user_id);

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -224,7 +224,7 @@ class PageControllerTest extends TestCase {
 		$this->assertEquals($url, $this->redirectUri);
 		parse_str($query, $parameters);
 		$this->assertTrue(array_key_exists('code', $parameters));
-		$expected = time() + 600;
+		$expected = time() + AuthorizationCode::EXPIRATION_TIME;
 		/** @var AuthorizationCode $authorizationCode */
 		$authorizationCode = $this->authorizationCodeMapper->findByCode($parameters['code']);
 		$this->assertEquals($expected, $authorizationCode->getExpires(), '', 1);

--- a/tests/Unit/Db/AccessTokenTest.php
+++ b/tests/Unit/Db/AccessTokenTest.php
@@ -34,7 +34,7 @@ class AccessTokenTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testResetExpires() {
-		$expected = time() + 3600;
+		$expected = time() + AccessToken::EXPIRATION_TIME;
 		$this->accessToken->resetExpires();
 		$this->assertEquals($expected, $this->accessToken->getExpires(), '', 1);
 	}

--- a/tests/Unit/Db/AuthorizationCodeTest.php
+++ b/tests/Unit/Db/AuthorizationCodeTest.php
@@ -34,7 +34,7 @@ class AuthorizationCodeTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testResetExpires() {
-		$expected = time() + 600;
+		$expected = time() + AuthorizationCode::EXPIRATION_TIME;
 		$this->authorizationCode->resetExpires();
 		$this->assertEquals($expected, $this->authorizationCode->getExpires(), '', 1);
 	}


### PR DESCRIPTION
Just so we get a unique reference of this value (e.g. the 'expires_in' value
on the access token JSON response was not bounded to the actual value, but
duplicated there).

Disclaimer: my PHP-fu is close to non-existent.