### PR TITLE
fix session password

### DIFF
--- a/lib/AuthModule.php
+++ b/lib/AuthModule.php
@@ -56,17 +56,18 @@ class AuthModule implements IAuthModule {
 	}
 
 	/**
-	 * Returns an empty string because the user's password is not handled in
-	 * the app.
+	 * Returns null because the user's password is not handled in the app.
+	 * Triggers a \OC\Authentication\Exceptions\PasswordlessTokenException when
+	 * verifying the session, @see \OC\User\Session::checkTokenCredentials().
 	 *
 	 * Note: This means that only master key encryption is working with the app.
 	 *
 	 * @param IRequest $request The request.
 	 *
-	 * @return String An empty string.
+	 * @return null
 	 */
 	public function getUserPassword(IRequest $request) {
-		return '';
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Found this while working on kerberos. Password should be `null` instead of `''` IIUC that null triggers `\OC\Authentication\Exceptions\PasswordlessTokenException` to make sessions without a password work properly. No idea if ther is magic in core that converts '' to null ... oracle certainly has that magic ... so no idea how this affects the overall auth with oauth2. 

- [ ] Also needs PHPDoc update in core