### PR TITLE
Debug log message when no bearer header found in request

### DIFF
--- a/lib/AuthModule.php
+++ b/lib/AuthModule.php
@@ -43,6 +43,7 @@ class AuthModule implements IAuthModule {
 		$authHeader = $request->getHeader('Authorization');
 
 		if (strpos($authHeader, 'Bearer ') === false) {
+			\OC::$server->getLogger()->debug('No Authorization: Bearer header detected', ['app' => 'oauth2']);
 			return null;
 		}
 


### PR DESCRIPTION
To aid debugging when apache/$webserver/$proxy strips the auth headers.
