### PR TITLE
Remove unneeded SKELETON_DIR in .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,7 +36,6 @@ pipeline:
       - BROWSER=chrome
       - SELENIUM_HOST=selenium
       - TEST_SERVER_URL=http://owncloud
-      - SKELETON_DIR=/var/www/owncloud/tests/acceptance/webUISkeleton
       - SELENIUM_PORT=4444
       - PLATFORM=Linux
       - BEHAT_SUITE=${BEHAT_SUITE}


### PR DESCRIPTION
SKELETON_DIR should have a correct default value in ``run.sh``, so it should not be needed here.

This will effectively implement the recent change of SKELETON_DIR location in core.