### PR TITLE
Add support for implicit grant

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -50,4 +50,7 @@ When using OAuth2 a unique access token is generated for each device or third pa
         <job>OCA\OAuth2\BackgroundJob\CleanUp</job>
     </background-jobs>
     <use-migrations>true</use-migrations>
+    <commands>
+        <command>OCA\OAuth2\Commands\AddClient</command>
+    </commands>
 </info>

--- a/lib/AuthModule.php
+++ b/lib/AuthModule.php
@@ -19,6 +19,7 @@
 
 namespace OCA\OAuth2;
 
+use OC\User\LoginException;
 use OCA\OAuth2\AppInfo\Application;
 use OCA\OAuth2\Db\AccessToken;
 use OCA\OAuth2\Db\AccessTokenMapper;
@@ -50,7 +51,7 @@ class AuthModule implements IAuthModule {
 
 		$user = $this->authToken($bearerToken);
 		if ($user === null) {
-			throw new \Exception('Invalid token');
+			throw new LoginException('Invalid token');
 		}
 		return $user;
 	}

--- a/lib/Commands/AddClient.php
+++ b/lib/Commands/AddClient.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\OAuth2\Commands;
+
+use OCA\OAuth2\Db\Client;
+use OCA\OAuth2\Db\ClientMapper;
+use OCA\OAuth2\Utilities;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class AddClient extends Command {
+
+	/** @var ClientMapper */
+	private $clientMapper;
+
+	public function __construct(ClientMapper $clientMapper) {
+		parent::__construct();
+
+		$this->clientMapper = $clientMapper;
+	}
+
+	protected function configure() {
+		$this
+			->setName('oauth2:add-client')
+			->setDescription('Adds an OAuth2 client')
+			->addArgument('name', InputArgument::REQUIRED,
+				'name of the client - will be displayed in the authorization page to the user')
+			->addArgument('client-id', InputArgument::REQUIRED,
+				'identifier of the client - used by the client during the implicit and authorization code flow')
+			->addArgument('client-secret', InputArgument::REQUIRED,
+				'secret of the client - used by the client during the authorization code flow')
+			->addArgument('redirect-url', InputArgument::REQUIRED,
+				'Redirect URL - used in the OAuth flows to post back tokens and authorization codes to the client')
+			->addArgument('allow-sub-domains', InputArgument::OPTIONAL,
+				'Defines if the redirect url is allowed to use sub domains. Enter true or false',
+				false);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$name = $input->getArgument('name');
+		$id = $input->getArgument('client-id');
+		$secret = $input->getArgument('client-secret');
+		$url = $input->getArgument('redirect-url');
+		$allowSubDomains = $input->getArgument('allow-sub-domains');
+
+		if (\strlen($id) < 32) {
+			throw new \InvalidArgumentException('The client id should be at least 32 characters long');
+		}
+		if (\strlen($secret) < 32) {
+			throw new \InvalidArgumentException('The client secret should be at least 32 characters long');
+		}
+		if (!Utilities::isValidUrl($url)) {
+			throw new \InvalidArgumentException('The redirect URL is not valid.');
+		}
+		if (!\is_bool($allowSubDomains)) {
+			throw new \InvalidArgumentException('Please enter true or false for allowed-sub-domains.');
+		}
+
+		$client = new Client();
+		$client->setIdentifier($id);
+		$client->setName($name);
+		$client->setRedirectUri($url);
+		$client->setSecret($secret);
+		$client->setAllowSubdomains($allowSubDomains);
+
+		$this->clientMapper->insert($client);
+	}
+}

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -27,7 +27,6 @@ use OCA\OAuth2\Db\AuthorizationCode;
 use OCA\OAuth2\Db\AuthorizationCodeMapper;
 use OCA\OAuth2\Db\Client;
 use OCA\OAuth2\Db\ClientMapper;
-use OCA\OAuth2\Db\RefreshTokenMapper;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
@@ -75,7 +74,7 @@ class PageControllerTest extends TestCase {
 		$app = new Application();
 		$container = $app->getContainer();
 
-		$this->clientMapper = $container->query('OCA\OAuth2\Db\ClientMapper');
+		$this->clientMapper = $container->query(ClientMapper::class);
 		$this->clientMapper->deleteAll();
 
 		/** @var Client $client */
@@ -87,24 +86,22 @@ class PageControllerTest extends TestCase {
 		$client->setAllowSubdomains(false);
 		$this->client = $this->clientMapper->insert($client);
 
-		$this->authorizationCodeMapper = $container->query('OCA\OAuth2\Db\AuthorizationCodeMapper');
+		$this->authorizationCodeMapper = $container->query(AuthorizationCodeMapper::class);
 		/** @var AccessTokenMapper $accessTokenMapper */
-		$accessTokenMapper = $container->query('OCA\OAuth2\Db\AccessTokenMapper');
-		/** @var RefreshTokenMapper $refreshTokenMapper */
-		$refreshTokenMapper = $container->query('OCA\OAuth2\Db\RefreshTokenMapper');
+		$accessTokenMapper = $container->query(AccessTokenMapper::class);
 		/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject $urlGenerator */
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject $userSession */
 		$userSession = $this->createMock(IUserSession::class);
 		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
 		$request = $this->createMock(IRequest::class);
-		/** @var IUser $user */
+		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
 		$user = $this->createMock(IUser::class);
 		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
 		$userManager = $this->createMock(IUserManager::class);
-		$userSession->expects($this->any())->method('getUser')->willReturn($user);
-		$userManager->expects($this->any())->method('get')->willReturn($user);
-		$user->expects($this->any())->method('getUID')->willReturn('Alice');
+		$userSession->method('getUser')->willReturn($user);
+		$userManager->method('get')->willReturn($user);
+		$user->method('getUID')->willReturn('Alice');
 
 		$this->controller = new PageController(
 			$container->query('AppName'),
@@ -112,7 +109,6 @@ class PageControllerTest extends TestCase {
 			$this->clientMapper,
 			$this->authorizationCodeMapper,
 			$accessTokenMapper,
-			$refreshTokenMapper,
 			$container->query('Logger'),
 			$urlGenerator,
 			$userSession,
@@ -129,7 +125,7 @@ class PageControllerTest extends TestCase {
 	public function testAuthorize() {
 		// Wrong types
 		$result = $this->controller->authorize(1, 'qwertz', 'abcd', 'state');
-		$this->assertTrue($result instanceof TemplateResponse);
+		$this->assertInstanceOf(TemplateResponse::class, $result);
 		$this->assertEquals('authorize-error', $result->getTemplateName());
 		$this->assertEquals(
 			['client_name' => null, 'back_url' => OC_Util::getDefaultPageUrl()],
@@ -137,7 +133,7 @@ class PageControllerTest extends TestCase {
 		);
 
 		$result = $this->controller->authorize('code', 2, 'abcd', 'state');
-		$this->assertTrue($result instanceof TemplateResponse);
+		$this->assertInstanceOf(TemplateResponse::class, $result);
 		$this->assertEquals('authorize-error', $result->getTemplateName());
 		$this->assertEquals(
 			['client_name' => null, 'back_url' => OC_Util::getDefaultPageUrl()],
@@ -145,7 +141,7 @@ class PageControllerTest extends TestCase {
 		);
 
 		$result = $this->controller->authorize('code', 'qwertz', 3, 'state');
-		$this->assertTrue($result instanceof TemplateResponse);
+		$this->assertInstanceOf(TemplateResponse::class, $result);
 		$this->assertEquals('authorize-error', $result->getTemplateName());
 		$this->assertEquals(
 			['client_name' => null, 'back_url' => OC_Util::getDefaultPageUrl()],
@@ -153,7 +149,7 @@ class PageControllerTest extends TestCase {
 		);
 
 		$result = $this->controller->authorize('code', $this->identifier, urldecode($this->redirectUri), 4);
-		$this->assertTrue($result instanceof TemplateResponse);
+		$this->assertInstanceOf(TemplateResponse::class, $result);
 		$this->assertEquals('authorize-error', $result->getTemplateName());
 		$this->assertEquals(
 			['client_name' => null, 'back_url' => OC_Util::getDefaultPageUrl()],
@@ -162,7 +158,7 @@ class PageControllerTest extends TestCase {
 
 		// Wrong parameters
 		$result = $this->controller->authorize('code', 'qwertz', 'abcd', 'state');
-		$this->assertTrue($result instanceof TemplateResponse);
+		$this->assertInstanceOf(TemplateResponse::class, $result);
 		$this->assertEquals('authorize-error', $result->getTemplateName());
 		$this->assertEquals(
 			['client_name' => null, 'back_url' => OC_Util::getDefaultPageUrl()],
@@ -170,7 +166,7 @@ class PageControllerTest extends TestCase {
 		);
 
 		$result = $this->controller->authorize('qwertz', $this->identifier, urldecode($this->redirectUri));
-		$this->assertTrue($result instanceof TemplateResponse);
+		$this->assertInstanceOf(TemplateResponse::class, $result);
 		$this->assertEquals('authorize-error', $result->getTemplateName());
 		$this->assertEquals(
 			['client_name' => $this->name, 'back_url' => OC_Util::getDefaultPageUrl()],
@@ -178,7 +174,7 @@ class PageControllerTest extends TestCase {
 		);
 
 		$result = $this->controller->authorize('code', $this->identifier, urldecode('https://www.example.org'));
-		$this->assertTrue($result instanceof TemplateResponse);
+		$this->assertInstanceOf(TemplateResponse::class, $result);
 		$this->assertEquals('authorize-error', $result->getTemplateName());
 		$this->assertEquals(
 			['client_name' => $this->name, 'back_url' => OC_Util::getDefaultPageUrl()],
@@ -186,7 +182,7 @@ class PageControllerTest extends TestCase {
 		);
 
 		$result = $this->controller->authorize('code', $this->identifier, urldecode($this->redirectUri));
-		$this->assertTrue($result instanceof TemplateResponse);
+		$this->assertInstanceOf(TemplateResponse::class, $result);
 		$this->assertEquals('authorize', $result->getTemplateName());
 		$this->assertEquals(['client_name' => $this->name], $result->getParams());
 	}
@@ -194,38 +190,38 @@ class PageControllerTest extends TestCase {
 	public function testGenerateAuthorizationCode() {
 		// Wrong types
 		$result = $this->controller->generateAuthorizationCode(1, 'qwertz', 'abcd', 'state');
-		$this->assertTrue($result instanceof RedirectResponse);
+		$this->assertInstanceOf(RedirectResponse::class, $result);
 		$this->assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
 
 		$result = $this->controller->generateAuthorizationCode('code', 2, 'abcd', 'state');
-		$this->assertTrue($result instanceof RedirectResponse);
+		$this->assertInstanceOf(RedirectResponse::class, $result);
 		$this->assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
 
 		$result = $this->controller->generateAuthorizationCode('code', 'qwertz', 3, 'state');
-		$this->assertTrue($result instanceof RedirectResponse);
+		$this->assertInstanceOf(RedirectResponse::class, $result);
 		$this->assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
 
 		$result = $this->controller->generateAuthorizationCode('code', $this->identifier, urldecode($this->redirectUri), 4);
-		$this->assertTrue($result instanceof RedirectResponse);
+		$this->assertInstanceOf(RedirectResponse::class, $result);
 		$this->assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
 
 		// Wrong parameters
-		$result = $this->controller->generateAuthorizationCode('code', 'qwertz', 'abcd', 'state', 'scope');
-		$this->assertTrue($result instanceof RedirectResponse);
+		$result = $this->controller->generateAuthorizationCode('code', 'qwertz', 'abcd', 'state');
+		$this->assertInstanceOf(RedirectResponse::class, $result);
 		$this->assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
 
 		$result = $this->controller->generateAuthorizationCode('qwertz', $this->identifier, urldecode($this->redirectUri));
-		$this->assertTrue($result instanceof RedirectResponse);
+		$this->assertInstanceOf(RedirectResponse::class, $result);
 		$this->assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
 
 		$result = $this->controller->generateAuthorizationCode('code', $this->identifier, urldecode('https://www.example.org'));
-		$this->assertTrue($result instanceof RedirectResponse);
+		$this->assertInstanceOf(RedirectResponse::class, $result);
 		$this->assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
 
-		$this->assertEquals(0, count($this->authorizationCodeMapper->findAll()));
+		$this->assertCount(0, $this->authorizationCodeMapper->findAll());
 		$result = $this->controller->generateAuthorizationCode('code', $this->identifier, urldecode($this->redirectUri));
-		$this->assertTrue($result instanceof RedirectResponse);
-		$this->assertEquals(1, count($this->authorizationCodeMapper->findAll()));
+		$this->assertInstanceOf(RedirectResponse::class, $result);
+		$this->assertCount(1, $this->authorizationCodeMapper->findAll());
 		list($url, $query) = explode('?', $result->getRedirectURL());
 		$this->assertEquals($url, $this->redirectUri);
 		parse_str($query, $parameters);
@@ -238,10 +234,10 @@ class PageControllerTest extends TestCase {
 		$this->assertEquals($this->client->getId(), $authorizationCode->getClientId());
 		$this->authorizationCodeMapper->delete($this->authorizationCodeMapper->findByCode($parameters['code']));
 
-		$this->assertEquals(0, count($this->authorizationCodeMapper->findAll()));
+		$this->assertCount(0, $this->authorizationCodeMapper->findAll());
 		$result = $this->controller->generateAuthorizationCode('code', $this->identifier, urldecode($this->redirectUri), 'testingState');
-		$this->assertTrue($result instanceof RedirectResponse);
-		$this->assertEquals(1, count($this->authorizationCodeMapper->findAll()));
+		$this->assertInstanceOf(RedirectResponse::class, $result);
+		$this->assertCount(1, $this->authorizationCodeMapper->findAll());
 		list($url, $query) = explode('?', $result->getRedirectURL());
 		$this->assertEquals($url, $this->redirectUri);
 		parse_str($query, $parameters);
@@ -259,7 +255,7 @@ class PageControllerTest extends TestCase {
 
 	public function testAuthorizationSuccessful() {
 		$result = $this->controller->authorizationSuccessful();
-		$this->assertTrue($result instanceof TemplateResponse);
+		$this->assertInstanceOf(TemplateResponse::class, $result);
 		$this->assertEquals('authorization-successful', $result->getTemplateName());
 	}
 


### PR DESCRIPTION
Fixes #165 

## Test Steps
0. add a new client using the occ command
```
 ./occ oauth2:add-client test clientid-1234567890-1234567890-1234567890 secret-secret-secret-secret-secret http://localhost:9999
```
1. open browser
http://own.cloud.local/index.php/apps/oauth2/authorize?response_type=token&client_id=clientid-1234567890-1234567890-1234567890&redirect_uri=http://localhost:9999

2. See authorization dialog - click button 'Authorize'

3. See login dialog - login

4. See redirect to url http://localhost:9999/?access_token=BBtaHzdCpXoRnN912G7hCPVcSHLSpKZbVF5tuwaLgxajj3mbpik7m2MHJOty1Vxk&expires_in=3600

5. this access_token can now be used to call e.g.
```sh
curl -v http://own.cloud.local/index.php/apps/oauth2/api/v1/arer BBtaHzdCpXoRnN912G7hCPVcSHLSpKZbVF5tuwaLgxajj3mbpik7m2MHJOty1Vxk'

