### PR TITLE
Bump max-version to 11.0.0.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -174,7 +174,7 @@ matrix:
       TEST_SUITE: phpunit
       DB_TYPE: sqlite
 
-    - PHP_VERSION: 7.2
+    - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit
       DB_TYPE: sqlite

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,7 +34,7 @@ When using OAuth2 a unique access token is generated for each device or third pa
     <screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/oauth2/ownCloud-oauth2-app-auth-request.jpg</screenshot>
     <screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/oauth2/ownCloud-oauth2-app-authorized.jpg</screenshot>
     <dependencies>
-        <owncloud min-version="10.0" max-version="10.1"/>
+        <owncloud min-version="10.0" max-version="11.0.0.0"/>
     </dependencies>
     <types>
         <authentication/>

--- a/tests/Unit/Sabre/AbstractBearerTest.php
+++ b/tests/Unit/Sabre/AbstractBearerTest.php
@@ -10,11 +10,11 @@ use Sabre\HTTP;
  * it in order to add compatibility with ownCloud 9.1, where an older version of
  * this library is used.
  */
-class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
+class AbstractBearerTest extends \PHPUnit\Framework\TestCase {
 
-	function testCheckNoHeaders() {
-
-		$request = new HTTP\Request();
+	public function testCheckNoHeaders()
+	{
+		$request = new HTTP\Request('GET', '/');
 		$response = new HTTP\Response();
 
 		$backend = new AbstractBearerMock();
@@ -22,13 +22,12 @@ class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse(
 			$backend->check($request, $response)[0]
 		);
-
 	}
 
-	function testCheckInvalidToken() {
-
-		$request = HTTP\Sapi::createFromServerArray([
-			'HTTP_AUTHORIZATION' => 'Bearer foo',
+	public function testCheckInvalidToken()
+	{
+		$request = new HTTP\Request('GET', '/', [
+			'Authorization' => 'Bearer foo',
 		]);
 		$response = new HTTP\Response();
 
@@ -37,13 +36,12 @@ class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse(
 			$backend->check($request, $response)[0]
 		);
-
 	}
 
-	function testCheckSuccess() {
-
-		$request = HTTP\Sapi::createFromServerArray([
-			'HTTP_AUTHORIZATION' => 'Bearer valid',
+	public function testCheckSuccess()
+	{
+		$request = new HTTP\Request('GET', '/', [
+			'Authorization' => 'Bearer valid',
 		]);
 		$response = new HTTP\Response();
 
@@ -52,12 +50,11 @@ class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
 			[true, 'principals/username'],
 			$backend->check($request, $response)
 		);
-
 	}
 
-	function testRequireAuth() {
-
-		$request = new HTTP\Request();
+	public function testRequireAuth()
+	{
+		$request = new HTTP\Request('GET', '/');
 		$response = new HTTP\Response();
 
 		$backend = new AbstractBearerMock();
@@ -68,27 +65,23 @@ class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
 			'Bearer realm="writing unittests on a saturday night"',
 			$response->getHeader('WWW-Authenticate')
 		);
-
 	}
-
 }
 
-
-class AbstractBearerMock extends AbstractBearer {
-
+class AbstractBearerMock extends AbstractBearer
+{
 	/**
-	 * Validates a bearer token
+	 * Validates a bearer token.
 	 *
 	 * This method should return true or false depending on if login
 	 * succeeded.
 	 *
 	 * @param string $bearerToken
+	 *
 	 * @return bool
 	 */
-	function validateBearerToken($bearerToken) {
-
+	public function validateBearerToken($bearerToken)
+	{
 		return 'valid' === $bearerToken ? 'principals/username' : false;
-
 	}
-
 }


### PR DESCRIPTION
1) Bump max-version to 11.0.0.0 like we did with all other apps
2) Copy changes from https://github.com/sabre-io/dav/blob/master/tests/Sabre/DAV/Auth/Backend/AbstractBearerTest.php to make unit tests pass against core master
3) The last 2 drone matrix entries were identical, testing PHP 7.2 with core master - change one of them so it tests with PHP 7.1