### PR TITLE
oAuth2 RefreshToken Lifetime added

### DIFF
--- a/lib/BackgroundJob/CleanUp.php
+++ b/lib/BackgroundJob/CleanUp.php
@@ -29,10 +29,16 @@ class CleanUp extends TimedJob {
 	 * @var AccessTokenMapper
 	 */
 	protected $accessTokenMapper;
+
 	/**
 	 * @var AuthorizationCodeMapper
 	 */
 	protected $authorizationCodeMapper;
+
+	/**
+	 * @var RefreshTokenMapper
+	 */
+	protected $refreshTokenMapper;
 
 	/**
 	 * Cron interval in seconds
@@ -41,9 +47,11 @@ class CleanUp extends TimedJob {
 
 	public function __construct(
 		AuthorizationCodeMapper $authorizationCodeMapper,
-		AccessTokenMapper $accessTokenMapper) {
+		AccessTokenMapper $accessTokenMapper,
+		RefreshTokenMapper $refreshTokenMapper) {
 		$this->authorizationCodeMapper = $authorizationCodeMapper;
 		$this->accessTokenMapper = $accessTokenMapper;
+		$this->refreshTokenMapper = $refreshTokenMapper;
 	}
 
 	/**
@@ -53,5 +61,7 @@ class CleanUp extends TimedJob {
 	public function run($argument) {
 		$this->authorizationCodeMapper->cleanUp();
 		$this->accessTokenMapper->cleanUp();
+		$this->refreshTokenMapper->cleanUp();
 	}
+
 }

--- a/lib/Controller/OAuthApiController.php
+++ b/lib/Controller/OAuthApiController.php
@@ -206,6 +206,7 @@ class OAuthApiController extends ApiController {
 		$refreshToken->setClientId($client->getId());
 		$refreshToken->setUserId($userId);
 		$refreshToken->setAccessTokenId($accessToken->getId());
+		$refreshToken->resetExpires();
 		$this->refreshTokenMapper->insert($refreshToken);
 
 		return new JSONResponse(

--- a/lib/Db/RefreshToken.php
+++ b/lib/Db/RefreshToken.php
@@ -32,10 +32,14 @@ use OCP\AppFramework\Db\Entity;
  * @method void setAccessTokenId(int $accessTokenId)
  */
 class RefreshToken extends Entity {
+
+	const EXPIRATION_DAYS = 30;
+
 	protected $token;
 	protected $clientId;
 	protected $userId;
 	protected $accessTokenId;
+	protected $expires;
 
 	public function __construct() {
 		$this->addType('id', 'int');
@@ -43,5 +47,23 @@ class RefreshToken extends Entity {
 		$this->addType('client_id', 'int');
 		$this->addType('user_id', 'string');
 		$this->addType('access_token_id', 'int');
+		$this->addType('expires', 'int');
 	}
+
+	/**
+	* Resets the expiry time to EXPIRATION_DAYS days from now.
+	*/
+	public function resetExpires() {
+		$this->setExpires(time() + (self::EXPIRATION_DAYS * 86400));
+	}
+
+	/**
+	* Determines if an refresh token has expired.
+	*
+	* @return boolean true if the refresh token has expired, false otherwise.
+	*/
+	public function hasExpired() {
+		return time() >= $this->getExpires();
+	}
+
 }


### PR DESCRIPTION
When an external authenticator is used for authentication with owncloud, than can a check over time with the original authenticator desirable. Next of an important security aspect to check whether the account is not already blocked there, it could be also desirable to exchange once in time the attributes such as the e-mail address and the display name again with the relevant back-end.

I have made a modification to the oAuth app that a Refresh Key will be removed after a lifetime of 30 days (hard coded), but maybe it's an idea to make this (EXPIRATION_DAYS) configurable in the config.php?

The only thing that needs to be added is a Migration step for; “ALTER TABLE oc_oauth2_refresh_tokens ADD expires int(10) unsigned;"
Are you able to make that for me, here I am not so handy with that.. Sorry. :(

Can you also check whether this is OK and of it can be added to the app?

Thanks!

Kind regards,

Tom Wezepoel

PS: New git request, where I tested again without the exit. Next of that I forgot the "protected $expires;" in the RefreshToken.php file.


@tomneedham ; Not from previous request - We should pull this from IConfig so that it can be set with occ and stored in oc_appconfig. So we should probably move this code to the Controller for now, and avoid the login / depdancy in here.