### PR TITLE
adjust acceptance test time constant names

### DIFF
--- a/tests/acceptance/features/lib/Oauth2AuthRequestPage.php
+++ b/tests/acceptance/features/lib/Oauth2AuthRequestPage.php
@@ -102,7 +102,7 @@ class Oauth2AuthRequestPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
@@ -118,7 +118,7 @@ class Oauth2AuthRequestPage extends OwncloudPage {
 			) {
 				break;
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 		


### PR DESCRIPTION
Old forms of the constant names were deprecated by https://github.com/owncloud/core/pull/32781/commits/db4608ace28ed62a00173021416951fb7ac3d994

Use the new forms that have underscores.