### PR TITLE
The redirect_uri needs to be encoded in the logout url

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -125,7 +125,7 @@ class PageController extends Controller {
 					'requesttoken' => Util::callRegister(),
 					'response_type' => $response_type,
 					'client_id' => $client_id,
-					'redirect_uri' => $redirect_uri,
+					'redirect_uri' => \urlencode($redirect_uri),
 					'state' => $state
 				]
 			);
@@ -172,7 +172,7 @@ class PageController extends Controller {
 				'requesttoken' => Util::callRegister(),
 				'response_type' => $response_type,
 				'client_id' => $client_id,
-				'redirect_uri' => $redirect_uri,
+				'redirect_uri' => \urlencode($redirect_uri),
 				'state' => $state
 			]
 		);


### PR DESCRIPTION
Without this urlencode the redirect_uri is getting lost on switching users.