### PR TITLE
Drop PHP 5.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -195,7 +195,7 @@ matrix:
     NEED_INSTALL_APP: true
     NEED_SERVER: true
 
-  - PHP_VERSION: 5.6
+  - PHP_VERSION: 7.0
     OC_VERSION: daily-stable10-qa
     TEST_SUITE: webui-acceptance
     BEHAT_SUITE: webUIOauth2
@@ -228,7 +228,7 @@ matrix:
     NEED_CORE: true
     NEED_INSTALL_APP: true
 
-  - PHP_VERSION: 5.6
+  - PHP_VERSION: 7.0
     OC_VERSION: daily-stable10-qa
     TEST_SUITE: phpunit
     DB_TYPE: sqlite

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,7 +34,7 @@ When using OAuth2 a unique access token is generated for each device or third pa
     <screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/oauth2/ownCloud-oauth2-app-auth-request.jpg</screenshot>
     <screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/oauth2/ownCloud-oauth2-app-authorized.jpg</screenshot>
     <dependencies>
-        <owncloud min-version="10" max-version="10"/>
+        <owncloud min-version="10.2" max-version="10"/>
     </dependencies>
     <types>
         <authentication/>

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "config" : {
         "platform": {
-            "php": "5.6.33"
+            "php": "7.0.8"
         }
     },
     "require": {


### PR DESCRIPTION
core stable10 no longer supports PHP 5.6
https://github.com/owncloud/core/pull/34698

- [x] adjust drone to no longer use PHP 5.6 anywhere
- [x] adjust local `composer` files to PHP 7.0.8
- [x] bump app core min-version to `10.2`