### PR TITLE
Adjust composer files to specify PHP 7.0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,11 @@
             "email": "thomas.mueller@tmit.eu"
         }
     ],
+    "config" : {
+        "platform": {
+            "php": "7.0.8"
+        }
+    },
     "require": {},
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "bfc230b6cf31d789217edbb15f84d9e9",
+    "content-hash": "fee4513efa0fe992c8905941499151c7",
     "packages": [],
     "packages-dev": [
         {
@@ -53,5 +53,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.0.8"
+    }
 }


### PR DESCRIPTION
Add the `platform` section in `composer.json` like we do in other apps.
In this case it does not make a difference to which versions of dependencies are chosen, but one day it might.

The other parts of dropping PHP 5.6 were all done in #202 already.