### PR TITLE
Phpunit 5 6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "bamarni/composer-bin-plugin",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bamarni/composer-bin-plugin.git",
-                "reference": "62fef740245a85f00665e81ea8f0aa0b72afe6e7"
+                "reference": "67f9d314dc7ecf7245b8637906e151ccc62b8d24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/62fef740245a85f00665e81ea8f0aa0b72afe6e7",
-                "reference": "62fef740245a85f00665e81ea8f0aa0b72afe6e7",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/67f9d314dc7ecf7245b8637906e151ccc62b8d24",
+                "reference": "67f9d314dc7ecf7245b8637906e151ccc62b8d24",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
             },
             "require-dev": {
                 "composer/composer": "dev-master",
-                "symfony/console": "^2.5 || ^3.0"
+                "symfony/console": "^2.5 || ^3.0 || ^4.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -44,7 +44,7 @@
             "license": [
                 "MIT"
             ],
-            "time": "2017-09-11T13:13:58+00:00"
+            "time": "2019-03-17T12:38:04+00:00"
         }
     ],
     "aliases": [],

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,9 @@
-<phpunit bootstrap="../../tests/bootstrap.php" colors="true">
+<phpunit bootstrap="../../tests/bootstrap.php"
+		 colors="true"
+		 verbose="true"
+		 failOnRisky="true"
+		 failOnWarning="true"
+>
     <testsuites>
         <testsuite name="unit">
             <directory>./tests/Unit</directory>

--- a/tests/Unit/AuthModuleTest.php
+++ b/tests/Unit/AuthModuleTest.php
@@ -26,10 +26,10 @@ use OCA\OAuth2\Db\AccessTokenMapper;
 use OCA\OAuth2\Db\Client;
 use OCA\OAuth2\Db\ClientMapper;
 use OCP\IUserManager;
-use PHPUnit_Framework_TestCase;
 use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
 
-class AuthModuleTest extends PHPUnit_Framework_TestCase {
+class AuthModuleTest extends TestCase {
 
 	/** @var IUserManager $userManager */
 	private $userManager;
@@ -98,7 +98,7 @@ class AuthModuleTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testAuth() {
 		// Wrong Authorization header
-		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->getMockBuilder(IRequest::class)->getMock();
 		$request->expects($this->once())
 			->method('getHeader')
@@ -125,7 +125,7 @@ class AuthModuleTest extends PHPUnit_Framework_TestCase {
 	public function testExpiredToken() {
 		$this->accessToken->setExpires(\time() - 1);
 		$this->accessTokenMapper->update($this->accessToken);
-		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->getMockBuilder(IRequest::class)->getMock();
 		$request->expects($this->once())
 			->method('getHeader')
@@ -140,7 +140,7 @@ class AuthModuleTest extends PHPUnit_Framework_TestCase {
 	 * @throws \Exception
 	 */
 	public function testInvalidToken() {
-		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->getMockBuilder(IRequest::class)->getMock();
 		$request->expects($this->once())
 			->method('getHeader')
@@ -150,7 +150,7 @@ class AuthModuleTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetUserPassword() {
-		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->getMockBuilder(IRequest::class)->getMock();
 		$this->assertEquals('', $this->authModule->getUserPassword($request));
 	}

--- a/tests/Unit/BackgroundJob/CleanUpTest.php
+++ b/tests/Unit/BackgroundJob/CleanUpTest.php
@@ -20,9 +20,9 @@
 namespace OCA\OAuth2\Tests\Unit\BackgroundJob;
 
 use OCA\OAuth2\BackgroundJob\CleanUp;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CleanUpTest extends PHPUnit_Framework_TestCase {
+class CleanUpTest extends TestCase {
 	public function testRun() {
 		$c = \OC::$server->query(CleanUp::class);
 		$c->run('');

--- a/tests/Unit/BackgroundJob/CleanUpTest.php
+++ b/tests/Unit/BackgroundJob/CleanUpTest.php
@@ -25,6 +25,6 @@ use PHPUnit\Framework\TestCase;
 class CleanUpTest extends TestCase {
 	public function testRun() {
 		$c = \OC::$server->query(CleanUp::class);
-		$c->run('');
+		$this->assertNull($c->run(''));
 	}
 }

--- a/tests/Unit/Controller/OAuthApiControllerTest.php
+++ b/tests/Unit/Controller/OAuthApiControllerTest.php
@@ -32,14 +32,14 @@ use OCA\OAuth2\Db\RefreshTokenMapper;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IURLGenerator;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class OAuthApiControllerTest extends PHPUnit_Framework_TestCase {
+class OAuthApiControllerTest extends TestCase {
 
 	/** @var OAuthApiController $controller */
 	private $controller;
 
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
 
 	/** @var ClientMapper $clientMapper */

--- a/tests/Unit/Controller/OpenIdConnectControllerTest.php
+++ b/tests/Unit/Controller/OpenIdConnectControllerTest.php
@@ -27,18 +27,19 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
 
-class OpenIdConnectControllerTest extends \PHPUnit_Framework_TestCase {
+class OpenIdConnectControllerTest extends TestCase {
 
 	/** @var OpenIdConnectController */
 	private $controller;
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	private $request;
-	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject */
 	private $userSession;
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
-	/** @var IAvatarManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IAvatarManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $avatarManager;
 
 	public function setUp() {
@@ -94,7 +95,7 @@ class OpenIdConnectControllerTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @param null $displayName
 	 * @param null $email
-	 * @return \PHPUnit_Framework_MockObject_MockObject
+	 * @return \PHPUnit\Framework\MockObject\MockObject
 	 */
 	public function createUserMock($displayName = null, $email = null) {
 		$user1 = $this->createMock(IUser::class);

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -89,15 +89,15 @@ class PageControllerTest extends TestCase {
 		$this->authorizationCodeMapper = $container->query(AuthorizationCodeMapper::class);
 		/** @var AccessTokenMapper $accessTokenMapper */
 		$accessTokenMapper = $container->query(AccessTokenMapper::class);
-		/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject $urlGenerator */
+		/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject $urlGenerator */
 		$urlGenerator = $this->createMock(IURLGenerator::class);
-		/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->createMock(IUserSession::class);
-		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
+		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock(IRequest::class);
-		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject $userManager */
 		$userManager = $this->createMock(IUserManager::class);
 		$userSession->method('getUser')->willReturn($user);
 		$userManager->method('get')->willReturn($user);

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -32,9 +32,9 @@ use OCA\OAuth2\Db\RefreshTokenMapper;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\IRequest;
 use OCP\IURLGenerator;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class SettingsControllerTest extends PHPUnit_Framework_TestCase {
+class SettingsControllerTest extends TestCase {
 
 	/** @var string $name */
 	private $appName;
@@ -54,7 +54,7 @@ class SettingsControllerTest extends PHPUnit_Framework_TestCase {
 	/** @var RefreshTokenMapper */
 	private $refreshTokenMapper;
 
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
 
 	/** @var string $userId */

--- a/tests/Unit/Db/AccessTokenMapperTest.php
+++ b/tests/Unit/Db/AccessTokenMapperTest.php
@@ -22,9 +22,9 @@ namespace OCA\OAuth2\Tests\Unit\Db;
 use OCA\OAuth2\AppInfo\Application;
 use OCA\OAuth2\Db\AccessToken;
 use OCA\OAuth2\Db\AccessTokenMapper;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class AccessTokenMapperTest extends PHPUnit_Framework_TestCase {
+class AccessTokenMapperTest extends TestCase {
 
 	/** @var AccessTokenMapper $accessTokenMapper */
 	private $accessTokenMapper;

--- a/tests/Unit/Db/AccessTokenTest.php
+++ b/tests/Unit/Db/AccessTokenTest.php
@@ -20,9 +20,9 @@
 namespace OCA\OAuth2\Tests\Unit\Db;
 
 use OCA\OAuth2\Db\AccessToken;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class AccessTokenTest extends PHPUnit_Framework_TestCase {
+class AccessTokenTest extends TestCase {
 
 	/** @var AccessToken $accessToken */
 	private $accessToken;

--- a/tests/Unit/Db/AuthorizationCodeMapperTest.php
+++ b/tests/Unit/Db/AuthorizationCodeMapperTest.php
@@ -22,9 +22,9 @@ namespace OCA\OAuth2\Tests\Unit\Db;
 use OCA\OAuth2\AppInfo\Application;
 use OCA\OAuth2\Db\AuthorizationCode;
 use OCA\OAuth2\Db\AuthorizationCodeMapper;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class AuthorizationCodeMapperTest extends PHPUnit_Framework_TestCase {
+class AuthorizationCodeMapperTest extends TestCase {
 
 	/** @var AuthorizationCodeMapper $authorizationCodeMapper */
 	private $authorizationCodeMapper;

--- a/tests/Unit/Db/AuthorizationCodeTest.php
+++ b/tests/Unit/Db/AuthorizationCodeTest.php
@@ -20,9 +20,9 @@
 namespace OCA\OAuth2\Tests\Unit\Db;
 
 use OCA\OAuth2\Db\AuthorizationCode;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class AuthorizationCodeTest extends PHPUnit_Framework_TestCase {
+class AuthorizationCodeTest extends TestCase {
 
 	/** @var AuthorizationCode $authorizationCode */
 	private $authorizationCode;

--- a/tests/Unit/Db/ClientMapperTest.php
+++ b/tests/Unit/Db/ClientMapperTest.php
@@ -26,9 +26,9 @@ use OCA\OAuth2\Db\AuthorizationCode;
 use OCA\OAuth2\Db\AuthorizationCodeMapper;
 use OCA\OAuth2\Db\Client;
 use OCA\OAuth2\Db\ClientMapper;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ClientMapperTest extends PHPUnit_Framework_TestCase {
+class ClientMapperTest extends TestCase {
 
 	/** @var ClientMapper $clientMapper */
 	private $clientMapper;

--- a/tests/Unit/Db/RefreshTokenMapperTest.php
+++ b/tests/Unit/Db/RefreshTokenMapperTest.php
@@ -19,7 +19,6 @@
 
 namespace OCA\OAuth2\Tests\Unit\Db;
 
-use Doctrine\DBAL\Platforms\SqlitePlatform;
 use OCA\OAuth2\AppInfo\Application;
 use OCA\OAuth2\Db\AccessToken;
 use OCA\OAuth2\Db\AccessTokenMapper;

--- a/tests/Unit/Db/RefreshTokenMapperTest.php
+++ b/tests/Unit/Db/RefreshTokenMapperTest.php
@@ -25,9 +25,9 @@ use OCA\OAuth2\Db\AccessToken;
 use OCA\OAuth2\Db\AccessTokenMapper;
 use OCA\OAuth2\Db\RefreshToken;
 use OCA\OAuth2\Db\RefreshTokenMapper;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class RefreshTokenMapperTest extends PHPUnit_Framework_TestCase {
+class RefreshTokenMapperTest extends TestCase {
 
 	/** @var RefreshTokenMapper $refreshTokenMapper */
 	private $refreshTokenMapper;

--- a/tests/Unit/Hooks/UserHooksTest.php
+++ b/tests/Unit/Hooks/UserHooksTest.php
@@ -46,6 +46,6 @@ class UserHooksTest extends TestCase {
 
 	public function testRegister() {
 		// Calling the register() function to check for exceptions.
-		$this->userHooks->register();
+		$this->assertNull($this->userHooks->register());
 	}
 }

--- a/tests/Unit/Hooks/UserHooksTest.php
+++ b/tests/Unit/Hooks/UserHooksTest.php
@@ -21,9 +21,9 @@ namespace OCA\OAuth2\Tests\Unit\Hooks;
 
 use OCA\OAuth2\AppInfo\Application;
 use OCA\OAuth2\Hooks\UserHooks;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class UserHooksTest extends PHPUnit_Framework_TestCase {
+class UserHooksTest extends TestCase {
 
 	/** @var UserHooks $userHooks */
 	private $userHooks;

--- a/tests/Unit/Sabre/OAuth2Test.php
+++ b/tests/Unit/Sabre/OAuth2Test.php
@@ -30,7 +30,7 @@ use OCA\OAuth2\Sabre\OAuth2;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 use OC\Session\Memory;
 use OC\User\User;
@@ -43,7 +43,7 @@ use OC\User\User;
  */
 class OAuth2Test extends TestCase {
 
-	/** @var IRequest | PHPUnit_Framework_MockObject_MockObject $request */
+	/** @var IRequest | PHPUnit\Framework\MockObject\MockObject $request */
 	private $request;
 
 	/** @var String $principalPrefix */
@@ -60,9 +60,9 @@ class OAuth2Test extends TestCase {
 	private $client;
 	/** @var AccessToken */
 	private $accessToken;
-	/** @var IUser | PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUser | PHPUnit\Framework\MockObject\MockObject */
 	private $user;
-	/** @var ISession | PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISession | PHPUnit\Framework\MockObject\MockObject */
 	private $session;
 
 	public function setUp() {
@@ -114,15 +114,15 @@ class OAuth2Test extends TestCase {
 
 	public function testIsDavAuthenticated() {
 		// User has not initially authenticated via DAV
-		/** @var ISession | PHPUnit_Framework_MockObject_MockObject $session */
+		/** @var ISession | PHPUnit\Framework\MockObject\MockObject $session */
 		$session = $this->createMock(Memory::class);
 		$session->expects($this->any())
 			->method('get')
 			->with($this->equalTo(OAuth2::DAV_AUTHENTICATED))
 			->willReturn(null);
-		/** @var Session | PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var Session | PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->createMock(Session::class);
-		/** @var AuthModule | PHPUnit_Framework_MockObject_MockObject $authModule */
+		/** @var AuthModule | PHPUnit\Framework\MockObject\MockObject $authModule */
 		$authModule = $this->createMock(AuthModule::class);
 		$oAuth2 = new OAuth2($session, $userSession, $this->request, $authModule, $this->principalPrefix);
 		$this->assertFalse(
@@ -139,7 +139,7 @@ class OAuth2Test extends TestCase {
 			->with($this->equalTo(OAuth2::DAV_AUTHENTICATED))
 			->willReturn($this->userId);
 		$userSession = $this->createMock(Session::class);
-		/** @var AuthModule | PHPUnit_Framework_MockObject_MockObject $authModule */
+		/** @var AuthModule | PHPUnit\Framework\MockObject\MockObject $authModule */
 		$authModule = $this->createMock(AuthModule::class);
 		$oAuth2 = new OAuth2($session, $userSession, $this->request, $authModule, $this->principalPrefix);
 		$this->assertTrue(
@@ -155,7 +155,7 @@ class OAuth2Test extends TestCase {
 	 * @param bool $invalidToken
 	 */
 	public function testValidateBearerTokenFailedLogin($invalidToken) {
-		/** @var Session | PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var Session | PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->createMock(Session::class);
 		$userSession->expects($this->any())
 			->method('getUser')
@@ -173,7 +173,7 @@ class OAuth2Test extends TestCase {
 				->method('tryAuthModuleLogin')
 				->willThrowException(new \Exception('Invalid token'));
 		}
-		/** @var AuthModule | PHPUnit_Framework_MockObject_MockObject $authModule */
+		/** @var AuthModule | PHPUnit\Framework\MockObject\MockObject $authModule */
 		$authModule = $this->createMock(AuthModule::class);
 		$oAuth2 = new OAuth2($this->session, $userSession, $this->request, $authModule, $this->principalPrefix);
 		$this->assertFalse(
@@ -186,7 +186,7 @@ class OAuth2Test extends TestCase {
 
 	public function testValidateBearerToken() {
 		// Successful login
-		/** @var Session | PHPUnit_Framework_MockObject_MockObject $userSession */
+		/** @var Session | PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->createMock(Session::class);
 		$userSession->expects($this->any())
 			->method('getUser')
@@ -197,7 +197,7 @@ class OAuth2Test extends TestCase {
 		$userSession->expects($this->once())
 			->method('tryAuthModuleLogin')
 			->willReturn(true);
-		/** @var AuthModule | PHPUnit_Framework_MockObject_MockObject $authModule */
+		/** @var AuthModule | PHPUnit\Framework\MockObject\MockObject $authModule */
 		$authModule = $this->createMock(AuthModule::class);
 		$oAuth2 = new OAuth2($this->session, $userSession, $this->request, $authModule, $this->principalPrefix);
 		$this->assertEquals(
@@ -222,7 +222,7 @@ class OAuth2Test extends TestCase {
 			->willReturn(true);
 
 		$john = $this->createMock(IUser::class);
-		/** @var AuthModule | PHPUnit_Framework_MockObject_MockObject $authModule */
+		/** @var AuthModule | PHPUnit\Framework\MockObject\MockObject $authModule */
 		$authModule = $this->createMock(AuthModule::class);
 		$authModule->expects($this->once())->method('authToken')->willReturn($john);
 		$oAuth2 = new OAuth2($this->session, $userSession, $this->request, $authModule, $this->principalPrefix);

--- a/tests/Unit/Sabre/OAuth2Test.php
+++ b/tests/Unit/Sabre/OAuth2Test.php
@@ -30,7 +30,6 @@ use OCA\OAuth2\Sabre\OAuth2;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
-use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 use OC\Session\Memory;
 use OC\User\User;

--- a/tests/Unit/UtilitiesTest.php
+++ b/tests/Unit/UtilitiesTest.php
@@ -20,9 +20,9 @@
 namespace OCA\OAuth2\Tests\Unit;
 
 use OCA\OAuth2\Utilities;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class UtilitiesTest extends PHPUnit_Framework_TestCase {
+class UtilitiesTest extends TestCase {
 	public function testGenerateRandom() {
 		$random = Utilities::generateRandom();
 

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -14,6 +14,7 @@ default:
             adminPassword: admin
             regularUserPassword: 123456
             ocPath: apps/testing/api/v1/occ
+        - OCSContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIUserContext:

--- a/tests/acceptance/features/bootstrap/Oauth2Context.php
+++ b/tests/acceptance/features/bootstrap/Oauth2Context.php
@@ -31,7 +31,6 @@ use TestHelpers\WebDavHelper;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use Page\Oauth2AdminSettingsPage;
-use TestHelpers\DownloadHelper;
 use TestHelpers\SetupHelper;
 
 require_once 'bootstrap.php';

--- a/tests/acceptance/features/bootstrap/Oauth2Context.php
+++ b/tests/acceptance/features/bootstrap/Oauth2Context.php
@@ -26,6 +26,7 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\Oauth2AuthRequestPage;
 use Page\Oauth2OnPersonalSecuritySettingsPage;
+use PHPUnit\Framework\Assert;
 use TestHelpers\WebDavHelper;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
@@ -208,7 +209,7 @@ class Oauth2Context extends RawMinkContext implements Context {
 		$this->clientAppRequestsAccessToken(
 			$this->accessTokenResponse->refresh_token
 		);
-		PHPUnit_Framework_Assert::assertNotSame(
+		Assert::assertNotSame(
 			$oldAccessToken, $this->accessTokenResponse->access_token,
 			__METHOD__ . " the new token is not different to the old one"
 		);
@@ -406,7 +407,7 @@ class Oauth2Context extends RawMinkContext implements Context {
 				$adminPassword
 			);
 			$downloadedContent = $result->getBody()->getContents();
-			PHPUnit_Framework_Assert::assertSame(
+			Assert::assertSame(
 				$localContent, $downloadedContent,
 				__METHOD__ . " content of downloaded file is not as expected"
 			);
@@ -420,20 +421,20 @@ class Oauth2Context extends RawMinkContext implements Context {
 	 */
 	public function clientAppShouldReceiveAuthCode() {
 		$redirectUri = \parse_url($this->getSession()->getCurrentUrl());
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 			$this->redirectUriHost, $redirectUri['host'],
 			__METHOD__ . " the host of redirect uri should be '" .
 			$this->redirectUriHost . "' but it is '" .
 			$redirectUri['host'] . "'"
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 			$this->redirectUriPort, $redirectUri['port'],
 			__METHOD__ . " the port of redirect uri should be '" .
 			$this->redirectUriPort . "' but it is '" .
 			$redirectUri['port'] . "'"
 		);
 		\parse_str($redirectUri['query'], $parameters);
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 			64, \strlen($parameters['code']),
 			__METHOD__ . " received code should be 64 char long but its " .
 			\strlen($parameters['code']) . " long"
@@ -447,7 +448,7 @@ class Oauth2Context extends RawMinkContext implements Context {
 	 */
 	public function invalidOauthRequestMessageShouldBeShown() {
 		$error = $this->oauth2AuthRequestPage->getErrorMessageHeading();
-		PHPUnit_Framework_Assert::assertSame("Request not valid", $error);
+		Assert::assertSame("Request not valid", $error);
 	}
 
 	/**
@@ -463,7 +464,7 @@ class Oauth2Context extends RawMinkContext implements Context {
 				" app should not be able to refresh token but looks like it can"
 			);
 		} catch (ClientException $e) {
-			PHPUnit_Framework_Assert::assertSame(
+			Assert::assertSame(
 				400, $e->getCode(),
 				__METHOD__ .
 				" expected '400' as HTTP error code, but received '" .
@@ -482,10 +483,10 @@ class Oauth2Context extends RawMinkContext implements Context {
 	 */
 	public function assertClientIsListedOnWebUI($name, $uri) {
 		$client = $this->oauth2AdminSettingsPage->getClientInformationByName($name);
-		PHPUnit_Framework_Assert::assertSame(
+		Assert::assertSame(
 			$name, $client['name'], "name of displayed client is wrong"
 		);
-		PHPUnit_Framework_Assert::assertSame(
+		Assert::assertSame(
 			$uri, $client['redirection_uri'], "uri of displayed client is wrong"
 		);
 	}


### PR DESCRIPTION
1) Adjust PHPUnit Framework namespace for PHPUnit6 
2) phpunit enable failOnRisky failOnWarning 
3) remove unused use statements 
4) Updating bamarni/composer-bin-plugin (v1.2.0 => v1.3.0)
