### PR TITLE
Specify Oracle DB name directly

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ pipeline:
     pull: true
     version: ${OC_VERSION}
     db_type: ${DB_TYPE}
-    db_name: ${DB_NAME=owncloud}
+    db_name: ${DB_NAME}
     db_host: ${DB_TYPE}
     db_username: autotest
     db_password: owncloud
@@ -172,7 +172,7 @@ services:
     environment:
       - MYSQL_USER=autotest
       - MYSQL_PASSWORD=owncloud
-      - MYSQL_DATABASE=${DB_NAME=owncloud}
+      - MYSQL_DATABASE=${DB_NAME}
       - MYSQL_ROOT_PASSWORD=owncloud
     when:
       matrix:
@@ -183,7 +183,7 @@ services:
     environment:
       - POSTGRES_USER=autotest
       - POSTGRES_PASSWORD=owncloud
-      - POSTGRES_DB=${DB_NAME=owncloud}
+      - POSTGRES_DB=${DB_NAME}
     when:
       matrix:
         DB_TYPE: pgsql
@@ -193,7 +193,7 @@ services:
     environment:
       - ORACLE_USER=system
       - ORACLE_PASSWORD=oracle
-      - ORACLE_DB=${DB_NAME=owncloud}
+      - ORACLE_DB=${DB_NAME}
     when:
       matrix:
         DB_TYPE: oci
@@ -219,6 +219,7 @@ matrix:
     OC_VERSION: daily-master-qa
     TEST_SUITE: phpunit
     DB_TYPE: mysql
+    DB_NAME: owncloud
     COVERAGE: true
     NEED_CORE: true
     NEED_INSTALL_APP: true
@@ -227,6 +228,7 @@ matrix:
     OC_VERSION: daily-master-qa
     TEST_SUITE: phpunit
     DB_TYPE: pgsql
+    DB_NAME: owncloud
     NEED_CORE: true
     NEED_INSTALL_APP: true
 
@@ -243,6 +245,7 @@ matrix:
     OC_VERSION: daily-master-qa
     TEST_SUITE: phpunit
     DB_TYPE: sqlite
+    DB_NAME: owncloud
     NEED_CORE: true
     NEED_INSTALL_APP: true
 
@@ -250,6 +253,7 @@ matrix:
     OC_VERSION: daily-master-qa
     TEST_SUITE: phpunit
     DB_TYPE: sqlite
+    DB_NAME: owncloud
     NEED_CORE: true
     NEED_INSTALL_APP: true
 
@@ -257,6 +261,7 @@ matrix:
     OC_VERSION: daily-master-qa
     TEST_SUITE: phpunit
     DB_TYPE: sqlite
+    DB_NAME: owncloud
     NEED_CORE: true
     NEED_INSTALL_APP: true
 


### PR DESCRIPTION
because the syntax `db_name: ${DB_NAME=owncloud}` does not get substituted properly by the automatic drone convert for the new drone version.