### PR TITLE
Improve adding a new client

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,3 +1,3 @@
-#form-inline {
+.form-inline {
 	display: inline;
 }

--- a/js/settings-admin.js
+++ b/js/settings-admin.js
@@ -1,0 +1,45 @@
+$(document).ready(function () {
+	$('#oauth2').on('click', '.grid .icon-delete', function (event) {
+		event.preventDefault();
+		OC.msg.startAction('#oauth2_save_msg', t('oauth2', 'Deleting...'));
+		$.post(
+			OC.generateUrl('apps/oauth2/clients/{id}/delete', {id: $(this).data('id')	}),
+			{},
+			function (data) {
+				OC.msg.finishedAction('#oauth2_save_msg', data);
+				if (data.data.errorMessage) {
+					OC.Notification.showTemporary(data.data.errorMessage);
+				} else if (data.clientIdentifier) {
+					$('.oauth2-identifier').filter(function () {
+						return $(this).text() === data.clientIdentifier;
+					}).parents('tr').first().remove();
+					if ($('.grid .oauth2-identifier').length === 0) {
+						$('#oauth2 .no-clients-message').removeClass('hidden');
+						$('#oauth2 .grid').addClass('hidden');
+					}
+				}
+			}
+		);
+	});
+	$('#oauth2_submit').on('click', function (event){
+		event.preventDefault();
+		OC.msg.startAction('#oauth2_save_msg', t('oauth2', 'Saving...'));
+		$.post(
+			OC.generateUrl('apps/oauth2/clients'),
+			$('#oauth2-new-client').serializeArray(),
+			function (data) {
+				OC.msg.finishedAction('#oauth2_save_msg', data);
+				if (data.data.errorMessage) {
+					OC.Notification.showTemporary(data.data.errorMessage);
+				} else {
+					$('#oauth2 .grid').removeClass('hidden');
+					$('#oauth2 .no-clients-message').addClass('hidden');
+					$('#oauth2 .grid tbody').append(data.rowHtml);
+					$('#oauth2 input[name ="name"]').val('');
+					$('#oauth2 input[name ="redirect_uri"]').val('');
+					$('#oauth2 input[name ="allow_subdomains"]').prop('checked', false);
+				}
+			}
+		);
+	});
+});

--- a/js/settings-admin.js
+++ b/js/settings-admin.js
@@ -3,12 +3,12 @@ $(document).ready(function () {
 		event.preventDefault();
 		OC.msg.startAction('#oauth2_save_msg', t('oauth2', 'Deleting...'));
 		$.post(
-			OC.generateUrl('apps/oauth2/clients/{id}/delete', {id: $(this).data('id')	}),
+			OC.generateUrl('apps/oauth2/clients/{id}/delete', {id: $(this).data('id')}),
 			{},
 			function (data) {
 				OC.msg.finishedAction('#oauth2_save_msg', data);
-				if (data.data.errorMessage) {
-					OC.Notification.showTemporary(data.data.errorMessage);
+				if (data.errorMessage) {
+					OC.Notification.showTemporary(data.errorMessage);
 				} else if (data.clientIdentifier) {
 					$('.oauth2-identifier').filter(function () {
 						return $(this).text() === data.clientIdentifier;
@@ -29,15 +29,15 @@ $(document).ready(function () {
 			$('#oauth2-new-client').serializeArray(),
 			function (data) {
 				OC.msg.finishedAction('#oauth2_save_msg', data);
-				if (data.data.errorMessage) {
-					OC.Notification.showTemporary(data.data.errorMessage);
+				if (data.errorMessage) {
+					OC.Notification.showTemporary(data.errorMessage);
 				} else {
 					$('#oauth2 .grid').removeClass('hidden');
 					$('#oauth2 .no-clients-message').addClass('hidden');
 					$('#oauth2 .grid tbody').append(data.rowHtml);
-					$('#oauth2 input[name ="name"]').val('');
-					$('#oauth2 input[name ="redirect_uri"]').val('');
-					$('#oauth2 input[name ="allow_subdomains"]').prop('checked', false);
+					$('#oauth2 input[name="name"]').val('');
+					$('#oauth2 input[name="redirect_uri"]').val('');
+					$('#oauth2 input[name="allow_subdomains"]').prop('checked', false);
 				}
 			}
 		);

--- a/lib/Commands/AddClient.php
+++ b/lib/Commands/AddClient.php
@@ -78,9 +78,17 @@ class AddClient extends Command {
 			throw new \InvalidArgumentException('Please enter true or false for allowed-sub-domains.');
 		}
 		try {
+			$this->clientMapper->findByName($name);
+			$output->writeln("Client name <$name> is already known.");
+			return 1;
+		} catch (DoesNotExistException $e) {
+			// this is good - name will be uniq
+		}
+
+		try {
 			$this->clientMapper->findByIdentifier($id);
 			$output->writeln("Client <$id> is already known.");
-			return;
+			return 1;
 		} catch (DoesNotExistException $ex) {
 			$client = new Client();
 			$client->setIdentifier($id);

--- a/lib/Commands/AddClient.php
+++ b/lib/Commands/AddClient.php
@@ -78,11 +78,12 @@ class AddClient extends Command {
 			throw new \InvalidArgumentException('Please enter true or false for allowed-sub-domains.');
 		}
 		try {
+			// the name should be uniq
 			$this->clientMapper->findByName($name);
 			$output->writeln("Client name <$name> is already known.");
 			return 1;
 		} catch (DoesNotExistException $e) {
-			// this is good - name will be uniq
+			// this is good - name is uniq
 		}
 
 		try {

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -92,14 +92,16 @@ class SettingsController extends Controller {
 	 * @return RedirectResponse Redirection to the settings page.
 	 */
 	public function addClient() {
-		if (!isset($_POST['redirect_uri']) || !isset($_POST['name'])) {
+		$redirectUri = $this->request->getParam('redirect_uri', null);
+		$name = $this->request->getParam('name', null);
+		if ($redirectUri === null || $name === null) {
 			return new RedirectResponse(
 				$this->urlGenerator->linkToRouteAbsolute(
 					'settings.SettingsPage.getAdmin',
 					['sectionid' => 'authentication']
 				) . '#oauth2');
 		}
-		if (!Utilities::isValidUrl($_POST['redirect_uri'])) {
+		if (!Utilities::isValidUrl($redirectUri)) {
 			return new RedirectResponse(
 				$this->urlGenerator->linkToRouteAbsolute(
 					'settings.SettingsPage.getAdmin',
@@ -110,14 +112,11 @@ class SettingsController extends Controller {
 		$client = new Client();
 		$client->setIdentifier(Utilities::generateRandom());
 		$client->setSecret(Utilities::generateRandom());
-		$client->setRedirectUri(\trim($_POST['redirect_uri']));
-		$client->setName(\trim($_POST['name']));
+		$client->setRedirectUri(\trim($redirectUri));
+		$client->setName(\trim($name));
 
-		if (isset($_POST['allow_subdomains'])) {
-			$client->setAllowSubdomains(true);
-		} else {
-			$client->setAllowSubdomains(false);
-		}
+		$allowSubdomains = $this->request->getParam('allow_subdomains', null) !== null;
+		$client->setAllowSubdomains($allowSubdomains);
 
 		$this->clientMapper->insert($client);
 

--- a/lib/Db/ClientMapper.php
+++ b/lib/Db/ClientMapper.php
@@ -75,6 +75,14 @@ class ClientMapper extends Mapper {
 		return $this->findEntity($sql, [$identifier], null, null);
 	}
 
+	public function findByName($name) {
+		if (!\is_string($name)) {
+			throw new InvalidArgumentException('name must not be null');
+		}
+		$sql = 'SELECT * FROM `' . $this->tableName . '` WHERE `name` = ?';
+		return $this->findEntity($sql, [$name], null, null);
+	}
+
 	/**
 	 * Selects all clients.
 	 *

--- a/lib/Panels/AdminPanel.php
+++ b/lib/Panels/AdminPanel.php
@@ -25,20 +25,13 @@ use OCP\Settings\ISettings;
 use OCP\Template;
 
 class AdminPanel implements ISettings {
-
 	/**
 	 * @var \OCA\OAuth2\Db\ClientMapper
 	 */
 	protected $clientMapper;
 
-	/**
-	 * @var IURLGenerator
-	 */
-	protected $urlGenerator;
-
-	public function __construct(ClientMapper $clientMapper, IURLGenerator $urlGenerator) {
+	public function __construct(ClientMapper $clientMapper) {
 		$this->clientMapper = $clientMapper;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	public function getSectionID() {
@@ -51,7 +44,6 @@ class AdminPanel implements ISettings {
 	public function getPanel() {
 		$t = new Template('oauth2', 'settings-admin');
 		$t->assign('clients', $this->clientMapper->findAll());
-		$t->assign('urlGenerator', $this->urlGenerator);
 		return $t;
 	}
 

--- a/templates/authorize.php
+++ b/templates/authorize.php
@@ -21,7 +21,7 @@ style('oauth2', 'authorization');
 ?>
 
 <span class="error">
-	<form id="form-inline" action="" method="post">
+	<form class="form-inline" action="" method="post">
 		<p>
 			<b><?php p($l->t('The “%s“ application would like permission to access your account', [$_['client_name']])); ?></b>
 		</p>

--- a/templates/client.part.php
+++ b/templates/client.part.php
@@ -7,8 +7,11 @@
 	<td><?php p($client->getRedirectUri()); ?></td>
 	<td><code class="oauth2-identifier"><?php p($client->getIdentifier()); ?></code></td>
 	<td><code><?php p($client->getSecret()); ?></code></td>
-	<td	<?php if ($client->getAllowSubdomains()) { ?> class="icon-32 icon-checkmark" <?php } ?> >
-	</td>
+<?php if ($client->getAllowSubdomains()): ?>
+	<td class="icon-32 icon-checkmark"></td>
+<?php else: ?>
+	<td></td>
+<?php endif; ?>
 	<td>
 		<button type="button" class="button icon-delete" data-id="<?php p($client->getId()) ?>"></button>
 	</td>

--- a/templates/client.part.php
+++ b/templates/client.part.php
@@ -1,0 +1,15 @@
+<?php if (isset($_['client'])) {
+	$client = $_['client'];
+} ?>
+
+<tr>
+	<td><?php p($client->getName()); ?></td>
+	<td><?php p($client->getRedirectUri()); ?></td>
+	<td><code class="oauth2-identifier"><?php p($client->getIdentifier()); ?></code></td>
+	<td><code><?php p($client->getSecret()); ?></code></td>
+	<td	<?php if ($client->getAllowSubdomains()) { ?> class="icon-32 icon-checkmark" <?php } ?> >
+	</td>
+	<td>
+		<button type="button" class="button icon-delete" data-id="<?php p($client->getId()) ?>"></button>
+	</td>
+</tr>

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -22,21 +22,23 @@ script('oauth2', 'settings-admin');
 style('oauth2', 'main');
 style('oauth2', 'settings-admin');
 
-$hasClients = !empty($_['clients']);
+if (!empty($_['clients'])) {
+	$noClientsExtraClass = 'hidden';
+	$clientTableExtraClass = '';
+} else {
+	$noClientsExtraClass = '';
+	$clientTableExtraClass = 'hidden';
+}
 ?>
 
 <div class="section" id="oauth2">
 	<h2 class="app-name"><?php p($l->t('OAuth 2.0')); ?></h2>
 
 	<h3><?php p($l->t('Registered clients')); ?></h3>
-	<p class="no-clients-message <?php if ($hasClients) {
-	p('hidden');
-}?>">
+	<p class="no-clients-message <?php p($noClientsExtraClass) ?>">
 		<?php p($l->t('No clients registered.')); ?>
 	</p>
-	<table class="grid <?php if (!$hasClients) {
-	p('hidden');
-}?>">
+	<table class="grid <?php p($clientTableExtraClass) ?>">
 		<thead>
 			<tr>
 				<th id="headerName" scope="col"><?php p($l->t('Name')); ?></th>
@@ -48,9 +50,11 @@ $hasClients = !empty($_['clients']);
 			</tr>
 		</thead>
 		<tbody>
-			<?php foreach ($_['clients'] as $client) {	?>
-				<?php include('client.part.php') ?>
-			<?php } ?>
+		<?php
+			foreach ($_['clients'] as $client):
+				include('client.part.php');
+			endforeach;
+		?>
 		</tbody>
 	</table>
 

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -18,62 +18,49 @@
  */
 
 /** @var \OCA\OAuth2\Db\Client $client */
-script('oauth2', 'settings');
+script('oauth2', 'settings-admin');
 style('oauth2', 'main');
 style('oauth2', 'settings-admin');
+
+$hasClients = !empty($_['clients']);
 ?>
 
 <div class="section" id="oauth2">
 	<h2 class="app-name"><?php p($l->t('OAuth 2.0')); ?></h2>
 
-    <h3><?php p($l->t('Registered clients')); ?></h3>
-    <?php if (empty($_['clients'])) {
-	p($l->t('No clients registered.'));
-} else {
-	?>
-    <table class="grid">
-        <thead>
-        <tr>
-            <th id="headerName" scope="col"><?php p($l->t('Name')); ?></th>
-            <th id="headerRedirectUri" scope="col"><?php p($l->t('Redirection URI')); ?></th>
-            <th id="headerClientIdentifier" scope="col"><?php p($l->t('Client Identifier')); ?></th>
-            <th id="headerSecret" scope="col"><?php p($l->t('Secret')); ?></th>
-			<th id="headerSubdomains" scope="col"><?php p($l->t('Subdomains allowed')); ?></th>
-            <th id="headerRemove">&nbsp;</th>
-        </tr>
-        </thead>
-        <tbody>
-            <?php foreach ($_['clients'] as $client) {
-		?>
-                <tr>
-                    <td><?php p($client->getName()); ?></td>
-                    <td><?php p($client->getRedirectUri()); ?></td>
-                    <td><code><?php p($client->getIdentifier()); ?></code></td>
-                    <td><code><?php p($client->getSecret()); ?></code></td>
-					<td id="td-allow-subdomains"
-					  <?php if ($client->getAllowSubdomains()) { ?> class="icon-32 icon-checkmark" <?php } ?> >
-					</td>
-                    <td>
-                        <form id="form-inline" class="delete" data-confirm="<?php p($l->t('Are you sure you want to delete this item?')); ?>" action="<?php p($_['urlGenerator']->linkToRoute('oauth2.settings.deleteClient', ['id' => $client->getId()])); ?>" method="post">
-							<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />
-                            <input type="submit" class="button icon-delete" value="">
-                        </form>
-                    </td>
-                </tr>
-            <?php
-	} ?>
-        </tbody>
-    </table>
-    <?php
-} ?>
+	<h3><?php p($l->t('Registered clients')); ?></h3>
+	<p class="no-clients-message <?php if ($hasClients) {
+	p('hidden');
+}?>">
+		<?php p($l->t('No clients registered.')); ?>
+	</p>
+	<table class="grid <?php if (!$hasClients) {
+	p('hidden');
+}?>">
+		<thead>
+			<tr>
+				<th id="headerName" scope="col"><?php p($l->t('Name')); ?></th>
+				<th id="headerRedirectUri" scope="col"><?php p($l->t('Redirection URI')); ?></th>
+				<th id="headerClientIdentifier" scope="col"><?php p($l->t('Client Identifier')); ?></th>
+				<th id="headerSecret" scope="col"><?php p($l->t('Secret')); ?></th>
+				<th id="headerSubdomains" scope="col"><?php p($l->t('Subdomains allowed')); ?></th>
+				<th id="headerRemove">&nbsp;</th>
+			</tr>
+		</thead>
+		<tbody>
+			<?php foreach ($_['clients'] as $client) {	?>
+				<?php include('client.part.php') ?>
+			<?php } ?>
+		</tbody>
+	</table>
 
-    <h3><?php p($l->t('Add client')); ?></h3>
-    <form action="<?php p($_['urlGenerator']->linkToRoute('oauth2.settings.addClient')); ?>" method="post">
-		<input id="name" name="name" type="text" placeholder="<?php p($l->t('Name')); ?>">
-        <input id="redirect_uri" name="redirect_uri" type="text" placeholder="<?php p($l->t('Redirection URI')); ?>">
-		<input type="checkbox" class="checkbox" name="allow_subdomains" id="allow_subdomains" value="1"/>
+	<h3><?php p($l->t('Add client')); ?></h3>
+	<form id="oauth2-new-client">
+		<input name="name" type="text" placeholder="<?php p($l->t('Name')); ?>">
+		<input name="redirect_uri" type="text" placeholder="<?php p($l->t('Redirection URI')); ?>">
+		<input name="allow_subdomains" id="allow_subdomains" type="checkbox" class="checkbox" value="1"/>
 		<label for="allow_subdomains"><?php p($l->t('Allow subdomains'));?></label>
-		<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />
-        <input type="submit" class="button" value="<?php p($l->t('Add')); ?>">
-    </form>
+	</form>
+	<button id="oauth2_submit" type="button" class="button"><?php p($l->t('Add')); ?></button>
+	<span id="oauth2_save_msg"></span>
 </div>

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -50,9 +50,9 @@ style('oauth2', 'settings-admin');
                     <td><?php p($client->getRedirectUri()); ?></td>
                     <td><code><?php p($client->getIdentifier()); ?></code></td>
                     <td><code><?php p($client->getSecret()); ?></code></td>
-					<td id="td-allow-subdomains"><?php if ($client->getAllowSubdomains()) {
-			?> <img alt="" src="/core/img/actions/checkmark.svg"> <?php
-		} ?></td>
+					<td id="td-allow-subdomains"
+					  <?php if ($client->getAllowSubdomains()) { ?> class="icon-32 icon-checkmark" <?php } ?> >
+					</td>
                     <td>
                         <form id="form-inline" class="delete" data-confirm="<?php p($l->t('Are you sure you want to delete this item?')); ?>" action="<?php p($_['urlGenerator']->linkToRoute('oauth2.settings.deleteClient', ['id' => $client->getId()])); ?>" method="post">
 							<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />

--- a/templates/settings-personal.php
+++ b/templates/settings-personal.php
@@ -43,7 +43,7 @@ style('oauth2', 'main');
 			<tr>
 				<td><?php p($client->getName()); ?></td>
 				<td>
-					<form id="form-inline" class="delete" data-confirm="<?php p($l->t('Are you sure you want to delete this item?')); ?>" action="<?php p($_['urlGenerator']->linkToRoute('oauth2.settings.revokeAuthorization', ['id' => $client->getId()])); ?>" method="post">
+					<form class="form-inline delete" data-confirm="<?php p($l->t('Are you sure you want to delete this item?')); ?>" action="<?php p($_['urlGenerator']->linkToRoute('oauth2.settings.revokeAuthorization', ['id' => $client->getId()])); ?>" method="post">
 						<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />
 						<input type="submit" class="button icon-delete" value="">
 					</form>

--- a/tests/Unit/Panel/AdminPanelTest.php
+++ b/tests/Unit/Panel/AdminPanelTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace OCA\OAuth2\Tests\Unit\Panel;
+
+use OCA\OAuth2\Db\ClientMapper;
+use OCA\OAuth2\Panels\AdminPanel;
+use PHPUnit\Framework\TestCase;
+
+class AdminPanelTest extends TestCase {
+	/** @var AdminPanel */
+	private $panel;
+
+	/** @var ClientMapper */
+	private $clientMapper;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->clientMapper = $this->createMock(ClientMapper::class);
+		$this->panel = new AdminPanel($this->clientMapper);
+	}
+
+	public function testPanel() {
+		$this->clientMapper->method('findAll')->willReturn([]);
+		$page = $this->panel->getPanel()->fetchPage();
+		$this->assertContains('No clients registered.', $page);
+	}
+}

--- a/tests/acceptance/features/lib/Oauth2AdminSettingsPage.php
+++ b/tests/acceptance/features/lib/Oauth2AdminSettingsPage.php
@@ -32,7 +32,7 @@ class Oauth2AdminSettingsPage extends OwncloudPage {
 	private $oauthAppNameInputId = "name";
 	private $oauthRedirectionUriInputId = "redirect_uri";
 	private $allowSubdomainsCheckBoxXpath = "//label[@for='allow_subdomains']";
-	private $addClientBtnXpath = "//*[@id='oauth2']//input[@value='Add']";
+	private $addClientBtnXpath = "//*[@id='oauth2']//button[@id='oauth2_submit']";
 	private $clientRowByNameXpath = "//*[@id='oauth2']//td[text()='%s']/../*";
 
 	/**
@@ -94,11 +94,8 @@ class Oauth2AdminSettingsPage extends OwncloudPage {
 		$result['redirection_uri'] = $tds[1]->getText();
 		$result['client_id'] = $tds[2]->getText();
 		$result['client_secret'] = $tds[3]->getText();
-		$actionLink = $tds[5]->find("xpath", "/form")->getAttribute("action");
-		$linkArray = \explode("/", $actionLink);
-		\end($linkArray);
-		$result['id'] = \prev($linkArray);
-		
+		$result['id'] = (int) $tds[5]->find("xpath", "/button")->getAttribute("data-id");
+
 		return $result;
 	}
 }


### PR DESCRIPTION
- [x] Ajaxifies adding and deleting clients via Web UI. Fixes #128 
-  [x] Fixes error 500 for web UI and unhandled `unqiueConstraintViolation` in CLI when a client with a duplicated name is added
Closes  https://github.com/owncloud/oauth2/issues/234  https://github.com/owncloud/oauth2/issues/162 https://github.com/owncloud/oauth2/issues/135

### Bonus
- [x] Fixes direct `_POST` usage in `SettingsController::addClient`
- [x] Fixes missing checkbox icon for `Subdomains allowed` column if OC is installed NOT into the webserver root
- [x] Fixes duplicated id warning in JS console  on the settings page 
