### PR TITLE
Fix: fail due to unneeded variable removal in webDavHelper

### DIFF
--- a/tests/acceptance/features/bootstrap/Oauth2Context.php
+++ b/tests/acceptance/features/bootstrap/Oauth2Context.php
@@ -380,7 +380,7 @@ class Oauth2Context extends RawMinkContext implements Context {
 		$result = WebDavHelper::makeDavRequest(
 			$this->featureContext->getBaseUrl(),
 			$user, $this->accessTokenResponse->access_token,
-			'GET', $file, [], null, null, 2, "files", null, "bearer"
+			'GET', $file, [], null, 2, "files", null, "bearer"
 		);
 		if (!$should && $result->getStatusCode() < 400) {
 			throw new \Exception(


### PR DESCRIPTION
This PR fixes https://drone.owncloud.com/owncloud/oauth2/848/12/11 caused due to https://github.com/owncloud/core/pull/36600
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- Fixes https://github.com/owncloud/oauth2/issues/246