### PR TITLE
Use realistic usernames

### DIFF
--- a/tests/acceptance/features/bootstrap/Oauth2Context.php
+++ b/tests/acceptance/features/bootstrap/Oauth2Context.php
@@ -115,8 +115,8 @@ class Oauth2Context extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When /^the user(?: "([^"]*)")? sends an oauth2 authorization request using the webUI$/
-	 * @Given /^the user(?: "([^"]*)")? has sent an oauth2 authorization request$/
+	 * @When /^user "([^"]*)" sends an oauth2 authorization request using the webUI$/
+	 * @Given /^user "([^"]*)" has sent an oauth2 authorization request$/
 	 *
 	 * @param string $username
 	 * @param string $clientId
@@ -139,6 +139,16 @@ class Oauth2Context extends RawMinkContext implements Context {
 			$fullUrl = $fullUrl . "&user=$username";
 		}
 		$this->visitPath($fullUrl);
+	}
+
+	/**
+	 * @When /^the user sends an oauth2 authorization request using the webUI$/
+	 * @Given /^the user has sent an oauth2 authorization request$/
+	 *
+	 * @return void
+	 */
+	public function theUserSendsOauthAuthorizationRequestUsingTheWebui() {
+		$this->oauthAuthorizationRequestUsingTheWebui();
 	}
 
 	/**
@@ -181,7 +191,7 @@ class Oauth2Context extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given the user :user has correctly established an oauth session
+	 * @Given user :user has correctly established an oauth session
 	 *
 	 * @param string $user
 	 *

--- a/tests/acceptance/features/webUIOauth2/enforceTokenAuth.feature
+++ b/tests/acceptance/features/webUIOauth2/enforceTokenAuth.feature
@@ -19,7 +19,7 @@ So that I can improve the security of the system by forbidding basic auth with u
 		Then the HTTP status code should be "200"
 
 	Scenario: using WebDAV with oauth when token auth is enforced
-		When user "user0" requests "/remote.php/webdav" with "PROPFIND" using basic auth
+		When user "user1" requests "/remote.php/webdav" with "PROPFIND" using basic auth
 		Then the HTTP status code should be "401"
 		When the user requests "/remote.php/webdav" with "PROPFIND" using oauth
 		Then the HTTP status code should be "207"

--- a/tests/acceptance/features/webUIOauth2/enforceTokenAuth.feature
+++ b/tests/acceptance/features/webUIOauth2/enforceTokenAuth.feature
@@ -10,7 +10,7 @@ So that I can improve the security of the system by forbidding basic auth with u
 			| username    | password | displayname  | email                 |
 			| user1       | 1234     | User One     | u1@oc.com.np          |
 		And token auth has been enforced
-		And the user "user1" has correctly established an oauth session
+		And user "user1" has correctly established an oauth session
 
 	Scenario: access files app with oauth when token auth is enforced
 		When user "user1" requests "/index.php/apps/files" with "GET" using basic auth

--- a/tests/acceptance/features/webUIOauth2/enforceTokenAuth.feature
+++ b/tests/acceptance/features/webUIOauth2/enforceTokenAuth.feature
@@ -1,52 +1,52 @@
 @webUI @insulated @disablePreviews
 Feature: enforce token auth
 
-As an administrator
-I want to be able to enforce token based auth
-So that I can improve the security of the system by forbidding basic auth with username & password
+  As an administrator
+  I want to be able to enforce token based auth
+  So that I can improve the security of the system by forbidding basic auth with username & password
 
-	Background:
-		Given these users have been created with skeleton files:
-			| username    | password | displayname  | email                 |
-			| user1       | 1234     | User One     | u1@oc.com.np          |
-		And token auth has been enforced
-		And user "user1" has correctly established an oauth session
+  Background:
+    Given these users have been created with skeleton files:
+      | username | password | displayname  | email             |
+      | Alice    | 1234     | Alice Hansen | alice@example.org |
+    And token auth has been enforced
+    And user "Alice" has correctly established an oauth session
 
-	Scenario: access files app with oauth when token auth is enforced
-		When user "user1" requests "/index.php/apps/files" with "GET" using basic auth
-		Then the HTTP status code should be "401"
-		When the user requests "/index.php/apps/files" with "GET" using oauth
-		Then the HTTP status code should be "200"
+  Scenario: access files app with oauth when token auth is enforced
+    When user "Alice" requests "/index.php/apps/files" with "GET" using basic auth
+    Then the HTTP status code should be "401"
+    When the user requests "/index.php/apps/files" with "GET" using oauth
+    Then the HTTP status code should be "200"
 
-	Scenario: using WebDAV with oauth when token auth is enforced
-		When user "user1" requests "/remote.php/webdav" with "PROPFIND" using basic auth
-		Then the HTTP status code should be "401"
-		When the user requests "/remote.php/webdav" with "PROPFIND" using oauth
-		Then the HTTP status code should be "207"
+  Scenario: using WebDAV with oauth when token auth is enforced
+    When user "Alice" requests "/remote.php/webdav" with "PROPFIND" using basic auth
+    Then the HTTP status code should be "401"
+    When the user requests "/remote.php/webdav" with "PROPFIND" using oauth
+    Then the HTTP status code should be "207"
 
-	Scenario: using OCS with oauth when token auth is enforced
-		When user "user1" requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic auth
-		Then the OCS status code should be "997"
-		And the HTTP status code should be "401"
-		When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using oauth
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
+  Scenario: using OCS with oauth when token auth is enforced
+    When user "Alice" requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic auth
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using oauth
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
 
-	@skip @issue_core_32068
-	Scenario: using OCS with oauth when token auth is enforced
-		When user "user1" requests "/ocs/v2.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic auth
-		Then the OCS status code should be "401"
-		And the HTTP status code should be "401"
-		When the user requests "/ocs/v2.php/apps/files_sharing/api/v1/remote_shares" with "GET" using oauth
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		
-	Scenario Outline: download a file with oauth when token auth is enforced
-		Given using <dav_version> DAV path
-		When user "user1" downloads file "/lorem.txt" using the WebDAV API
-		Then the HTTP status code should be "401"
-		But the client app should be able to download the file "lorem.txt" of "user1" using the access token for authentication
-		Examples:
-			| dav_version   |
-			| old           |
-			| new           |
+  @skip @issue_core_32068
+  Scenario: using OCS with oauth when token auth is enforced
+    When user "Alice" requests "/ocs/v2.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic auth
+    Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    When the user requests "/ocs/v2.php/apps/files_sharing/api/v1/remote_shares" with "GET" using oauth
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+
+  Scenario Outline: download a file with oauth when token auth is enforced
+    Given using <dav_version> DAV path
+    When user "Alice" downloads file "/lorem.txt" using the WebDAV API
+    Then the HTTP status code should be "401"
+    But the client app should be able to download the file "lorem.txt" of "Alice" using the access token for authentication
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/webUIOauth2/newClientRegistration.feature
+++ b/tests/acceptance/features/webUIOauth2/newClientRegistration.feature
@@ -1,24 +1,24 @@
 @webUI @insulated @disablePreviews
 Feature: register a new client
-	As an admin
-	I want to be able to register new clients
-	So that private set of client_ids and client_secrets can be used
+  As an admin
+  I want to be able to register new clients
+  So that private set of client_ids and client_secrets can be used
 
-	Scenario: register a new client on the webUI
-		Given user admin has logged in using the webUI
-		And the administrator has browsed to the oauth admin settings page
-		When the administrator adds a new oauth client with the name "new client" and the uri "http://localhost:*" using the webUI
-		Then a new client with the name "new client" and the uri "http://localhost:*" should be listed on the webUI
+  Scenario: register a new client on the webUI
+    Given user admin has logged in using the webUI
+    And the administrator has browsed to the oauth admin settings page
+    When the administrator adds a new oauth client with the name "new client" and the uri "http://localhost:*" using the webUI
+    Then a new client with the name "new client" and the uri "http://localhost:*" should be listed on the webUI
 
-	Scenario: oauth authorization with a new client
-		Given these users have been created with skeleton files:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
-			|user2   |1234    |User Two   |u2@oc.com.np|
-		And the administrator has added a new oauth client with the name "client1" and the uri "http://localhost:*"
-		When the user sends an oauth2 authorization request with the new client-id using the webUI
-		And the user logs in with username "user1" and password "1234" using the webUI after a redirect from the oauth2AuthRequest page
-		And the user authorizes the oauth app using the webUI
-		And the client app requests an access token with the new client-id and client-secret
-		Then the client app should be able to download the file "lorem.txt" of "user1" using the access token for authentication
-		But the client app should not be able to download the file "lorem.txt" of "user2" using the access token for authentication
+  Scenario: oauth authorization with a new client
+    Given these users have been created with skeleton files:
+      | username | password | displayname  | email             |
+      | Alice    | 1234     | Alice Hansen | alice@example.org |
+      | Brian    | 1234     | Brian Murphy | brian@example.org |
+    And the administrator has added a new oauth client with the name "client1" and the uri "http://localhost:*"
+    When the user sends an oauth2 authorization request with the new client-id using the webUI
+    And the user logs in with username "Alice" and password "1234" using the webUI after a redirect from the oauth2AuthRequest page
+    And the user authorizes the oauth app using the webUI
+    And the client app requests an access token with the new client-id and client-secret
+    Then the client app should be able to download the file "lorem.txt" of "Alice" using the access token for authentication
+    But the client app should not be able to download the file "lorem.txt" of "Brian" using the access token for authentication

--- a/tests/acceptance/features/webUIOauth2/obtainAccessToken.feature
+++ b/tests/acceptance/features/webUIOauth2/obtainAccessToken.feature
@@ -30,19 +30,19 @@ Feature: obtaining an access token
 		Given these users have been created with skeleton files:
 			|username|password|displayname|email       |
 			|user2   |1234    |User Two   |u2@oc.com.np|
-		And the user "user1" has correctly established an oauth session
+		And user "user1" has correctly established an oauth session
 		When the client app refreshes the access token
 		Then the client app should be able to download the file "lorem.txt" of "user1" using the access token for authentication
 		But the client app should not be able to download the file "lorem.txt" of "user2" using the access token for authentication
 
 	Scenario: use OCS with oauth
-		Given the user "user1" has correctly established an oauth session
+		Given user "user1" has correctly established an oauth session
 		When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using oauth
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: use OCS with oauth
-		Given the user "user1" has correctly established an oauth session
+		Given user "user1" has correctly established an oauth session
 		When the user requests "/ocs/v2.php/apps/files_sharing/api/v1/remote_shares" with "GET" using oauth
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
@@ -66,7 +66,7 @@ Feature: obtaining an access token
 			|user2   |1234    |User Two   |u2@oc.com.np|
 		And the user has browsed to the login page
 		And the user has logged in with username "user1" and password "1234" using the webUI
-		When the user "user2" sends an oauth2 authorization request using the webUI
+		When user "user2" sends an oauth2 authorization request using the webUI
 		And the user switches the user to continue the oauth process using the webUI
 		And the user logs in with username "user2" and password "1234" using the webUI after a redirect from the oauth2AuthRequest page
 		And the user authorizes the oauth app using the webUI

--- a/tests/acceptance/features/webUIOauth2/obtainAccessToken.feature
+++ b/tests/acceptance/features/webUIOauth2/obtainAccessToken.feature
@@ -1,83 +1,83 @@
 @webUI @insulated @disablePreviews
 Feature: obtaining an access token
-	As a user
-	I want to be able to receive and use oauth tokens for authentication
-	So that I do not need to entrust various apps with my ownCloud password
+  As a user
+  I want to be able to receive and use oauth tokens for authentication
+  So that I do not need to entrust various apps with my ownCloud password
 
-	Background:
-		Given these users have been created with skeleton files:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+  Background:
+    Given these users have been created with skeleton files:
+      | username | password | displayname  | email             |
+      | Alice    | 1234     | Alice Hansen | alice@example.org |
 
-	Scenario: receive an authorization code
-		When the user sends an oauth2 authorization request using the webUI
-		And the user logs in with username "user1" and password "1234" using the webUI after a redirect from the oauth2AuthRequest page
-		And the user authorizes the oauth app using the webUI
-		Then the client app should receive an authorization code
+  Scenario: receive an authorization code
+    When the user sends an oauth2 authorization request using the webUI
+    And the user logs in with username "Alice" and password "1234" using the webUI after a redirect from the oauth2AuthRequest page
+    And the user authorizes the oauth app using the webUI
+    Then the client app should receive an authorization code
 
-	Scenario: receive an access token and use it to access a file
-		Given these users have been created with skeleton files:
-			|username|password|displayname|email       |
-			|user2   |1234    |User Two   |u2@oc.com.np|
-		When the user sends an oauth2 authorization request using the webUI
-		And the user logs in with username "user1" and password "1234" using the webUI after a redirect from the oauth2AuthRequest page
-		And the user authorizes the oauth app using the webUI
-		And the client app requests an access token
-		Then the client app should be able to download the file "lorem.txt" of "user1" using the access token for authentication
-		But the client app should not be able to download the file "lorem.txt" of "user2" using the access token for authentication
+  Scenario: receive an access token and use it to access a file
+    Given these users have been created with skeleton files:
+      | username | password | displayname  | email             |
+      | Brian    | 1234     | Brian Murphy | brian@example.org |
+    When the user sends an oauth2 authorization request using the webUI
+    And the user logs in with username "Alice" and password "1234" using the webUI after a redirect from the oauth2AuthRequest page
+    And the user authorizes the oauth app using the webUI
+    And the client app requests an access token
+    Then the client app should be able to download the file "lorem.txt" of "Alice" using the access token for authentication
+    But the client app should not be able to download the file "lorem.txt" of "Brian" using the access token for authentication
 
-	Scenario: receive a new access token by using the refresh token
-		Given these users have been created with skeleton files:
-			|username|password|displayname|email       |
-			|user2   |1234    |User Two   |u2@oc.com.np|
-		And user "user1" has correctly established an oauth session
-		When the client app refreshes the access token
-		Then the client app should be able to download the file "lorem.txt" of "user1" using the access token for authentication
-		But the client app should not be able to download the file "lorem.txt" of "user2" using the access token for authentication
+  Scenario: receive a new access token by using the refresh token
+    Given these users have been created with skeleton files:
+      | username | password | displayname  | email             |
+      | Brian    | 1234     | Brian Murphy | brian@example.org |
+    And user "Alice" has correctly established an oauth session
+    When the client app refreshes the access token
+    Then the client app should be able to download the file "lorem.txt" of "Alice" using the access token for authentication
+    But the client app should not be able to download the file "lorem.txt" of "Brian" using the access token for authentication
 
-	Scenario: use OCS with oauth
-		Given user "user1" has correctly established an oauth session
-		When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using oauth
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
+  Scenario: use OCS with oauth
+    Given user "Alice" has correctly established an oauth session
+    When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using oauth
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
 
-	Scenario: use OCS with oauth
-		Given user "user1" has correctly established an oauth session
-		When the user requests "/ocs/v2.php/apps/files_sharing/api/v1/remote_shares" with "GET" using oauth
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
+  Scenario: use OCS with oauth
+    Given user "Alice" has correctly established an oauth session
+    When the user requests "/ocs/v2.php/apps/files_sharing/api/v1/remote_shares" with "GET" using oauth
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
 
-	Scenario: receive an access token when user is already logged in and use it to access a file
-		Given the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
-		When the user sends an oauth2 authorization request using the webUI
-		And the user authorizes the oauth app using the webUI
-		And the client app requests an access token
-		Then the client app should be able to download the file "lorem.txt" of "user1" using the access token for authentication
+  Scenario: receive an access token when user is already logged in and use it to access a file
+    Given the user has browsed to the login page
+    And the user has logged in with username "Alice" and password "1234" using the webUI
+    When the user sends an oauth2 authorization request using the webUI
+    And the user authorizes the oauth app using the webUI
+    And the client app requests an access token
+    Then the client app should be able to download the file "lorem.txt" of "Alice" using the access token for authentication
 
-	Scenario: try to receive an authorization code with an unregistered client
-		When the user sends an oauth2 authorization request with an unregistered clientId using the webUI
-		And the user logs in with username "user1" and password "1234" using the webUI after a redirect from the oauth2AuthRequest page
-		Then an invalid oauth request message should be shown
+  Scenario: try to receive an authorization code with an unregistered client
+    When the user sends an oauth2 authorization request with an unregistered clientId using the webUI
+    And the user logs in with username "Alice" and password "1234" using the webUI after a redirect from the oauth2AuthRequest page
+    Then an invalid oauth request message should be shown
 
-	Scenario: receive an access token for a user that is different to the currently logged in user
-		Given these users have been created with skeleton files:
-			|username|password|displayname|email       |
-			|user2   |1234    |User Two   |u2@oc.com.np|
-		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
-		When user "user2" sends an oauth2 authorization request using the webUI
-		And the user switches the user to continue the oauth process using the webUI
-		And the user logs in with username "user2" and password "1234" using the webUI after a redirect from the oauth2AuthRequest page
-		And the user authorizes the oauth app using the webUI
-		And the client app requests an access token
-		Then the client app should be able to download the file "lorem.txt" of "user2" using the access token for authentication
+  Scenario: receive an access token for a user that is different to the currently logged in user
+    Given these users have been created with skeleton files:
+      | username | password | displayname  | email             |
+      | Brian    | 1234     | Brian Murphy | brian@example.org |
+    And the user has browsed to the login page
+    And the user has logged in with username "Alice" and password "1234" using the webUI
+    When user "Brian" sends an oauth2 authorization request using the webUI
+    And the user switches the user to continue the oauth process using the webUI
+    And the user logs in with username "Brian" and password "1234" using the webUI after a redirect from the oauth2AuthRequest page
+    And the user authorizes the oauth app using the webUI
+    And the client app requests an access token
+    Then the client app should be able to download the file "lorem.txt" of "Brian" using the access token for authentication
 
-	Scenario: receive an access token after invalid password entry
-		When the user sends an oauth2 authorization request using the webUI
-		And the user logs in with username "user1" and invalid password "wrong" using the webUI
-		And the user logs in with username "user1" and password "1234" using the webUI after a redirect from the oauth2AuthRequest page
-		And the user authorizes the oauth app using the webUI
-		And the client app requests an access token
-		Then the client app should be able to download the file "lorem.txt" of "user1" using the access token for authentication
+  Scenario: receive an access token after invalid password entry
+    When the user sends an oauth2 authorization request using the webUI
+    And the user logs in with username "Alice" and invalid password "wrong" using the webUI
+    And the user logs in with username "Alice" and password "1234" using the webUI after a redirect from the oauth2AuthRequest page
+    And the user authorizes the oauth app using the webUI
+    And the client app requests an access token
+    Then the client app should be able to download the file "lorem.txt" of "Alice" using the access token for authentication
 		

--- a/tests/acceptance/features/webUIOauth2/revokeAccessToken.feature
+++ b/tests/acceptance/features/webUIOauth2/revokeAccessToken.feature
@@ -1,22 +1,22 @@
 @webUI @insulated @disablePreviews
 Feature: revoke an access token
-	As a user
-	I want to be able to revoke an oauth token
-	So that I can stop a previous permitted application accessing my data
+  As a user
+  I want to be able to revoke an oauth token
+  So that I can stop a previous permitted application accessing my data
 
-	Background:
-		Given these users have been created with skeleton files:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+  Background:
+    Given these users have been created with skeleton files:
+      | username | password | displayname  | email             |
+      | Alice    | 1234     | Alice Hansen | alice@example.org |
 
-	Scenario: revoke an access token by webUI
-		Given user "user1" has correctly established an oauth session
-		And the user has browsed to the personal security settings page
-		When the user revokes the oauth app "Desktop Client" using the webUI
-		Then the client app should not be able to download the file "lorem.txt" of "user1" using the access token for authentication
+  Scenario: revoke an access token by webUI
+    Given user "Alice" has correctly established an oauth session
+    And the user has browsed to the personal security settings page
+    When the user revokes the oauth app "Desktop Client" using the webUI
+    Then the client app should not be able to download the file "lorem.txt" of "Alice" using the access token for authentication
 
-	Scenario: receiving a new access token by using the refresh token should not work after revoking the app
-		Given user "user1" has correctly established an oauth session
-		And the user has browsed to the personal security settings page
-		When the user revokes the oauth app "Desktop Client" using the webUI
-		Then the client app should not be able to refresh the access token
+  Scenario: receiving a new access token by using the refresh token should not work after revoking the app
+    Given user "Alice" has correctly established an oauth session
+    And the user has browsed to the personal security settings page
+    When the user revokes the oauth app "Desktop Client" using the webUI
+    Then the client app should not be able to refresh the access token

--- a/tests/acceptance/features/webUIOauth2/revokeAccessToken.feature
+++ b/tests/acceptance/features/webUIOauth2/revokeAccessToken.feature
@@ -10,13 +10,13 @@ Feature: revoke an access token
 		|user1   |1234    |User One   |u1@oc.com.np|
 
 	Scenario: revoke an access token by webUI
-		Given the user "user1" has correctly established an oauth session
+		Given user "user1" has correctly established an oauth session
 		And the user has browsed to the personal security settings page
 		When the user revokes the oauth app "Desktop Client" using the webUI
 		Then the client app should not be able to download the file "lorem.txt" of "user1" using the access token for authentication
 
 	Scenario: receiving a new access token by using the refresh token should not work after revoking the app
-		Given the user "user1" has correctly established an oauth session
+		Given user "user1" has correctly established an oauth session
 		And the user has browsed to the personal security settings page
 		When the user revokes the oauth app "Desktop Client" using the webUI
 		Then the client app should not be able to refresh the access token


### PR DESCRIPTION
Similar to what was done in core recently.

1) Adjust some step text so we can write `When user "user1"
2) Fix an error in a scenario that accidentally used `user1` that does not exist anyway.
3) Use realistic usernames