### PR TITLE
Adjust phpstan.neon so it passes

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,8 @@
 parameters:
   inferPrivatePropertyTypeFromConstructor: true
   treatPhpDocTypesAsCertain: false
-  bootstrap: %currentWorkingDirectory%/../../lib/base.php
+  bootstrapFiles:
+    - %currentWorkingDirectory%/../../lib/base.php
   excludes_analyse:
     - %currentWorkingDirectory%/appinfo/Migrations/*.php
   ignoreErrors:
-    - '#Parameter \#2 \$value of method OC\\Template\\Base::assign() expects array|bool|int|string, OCP\\IURLGenerator given.#'


### PR DESCRIPTION
The PHPdoc of `OC\\Template\\Base::assign()` was fixed in core yesterday PR https://github.com/owncloud/core/pull/37503 so the "error" no longer needs to be ignored.