### PR TITLE
implement the oauth2 pkce extension

### DIFF
--- a/appinfo/Migrations/Version20201126140622.php
+++ b/appinfo/Migrations/Version20201126140622.php
@@ -1,0 +1,19 @@
+<?php
+namespace OCA\oauth2\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use OCP\Migration\ISchemaMigration;
+
+class Version20201126140622 implements ISchemaMigration {
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+		$table = $schema->getTable("{$prefix}oauth2_auth_codes");
+		if (!$table->hasColumn('code_challenge')) {
+			$table->addColumn('code_challenge', Type::STRING, ['notNull' => false]);
+		}
+		if (!$table->hasColumn('code_challenge_method')) {
+			$table->addColumn('code_challenge_method', Type::STRING, ['notNull' => false]);
+		}
+	}
+}

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,7 +24,7 @@ When using OAuth2 a unique access token is generated for each device or third pa
 - [OAuth protocol web page](https://oauth.net/2/)</description>
     <licence>AGPL</licence>
     <author>Project Seminar "sciebo@Learnweb" of the University of Münster, Thomas Müller</author>
-    <version>0.4.4</version>
+    <version>0.5.0</version>
     <namespace>OAuth2</namespace>
     <category>security</category>
     <website>https://github.com/owncloud/oauth2</website>

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -200,6 +200,8 @@ class PageController extends Controller {
 	 * @param string $client_id The client identifier.
 	 * @param string $redirect_uri The redirection URI.
 	 * @param string $state The state.
+	 * @param string $code_challenge The PKCE code challenge.
+	 * @param string $code_challenge_method The PKCE code challenge method.
 	 *
 	 * @return RedirectResponse Redirection to the given redirect_uri or to the
 	 * default page URL.
@@ -207,7 +209,7 @@ class PageController extends Controller {
 	 * @throws MultipleObjectsReturnedException
 	 * @NoAdminRequired
 	 */
-	public function generateAuthorizationCode($response_type, $client_id, $redirect_uri, $state = null) {
+	public function generateAuthorizationCode($response_type, $client_id, $redirect_uri, $state = null, $code_challenge = null, $code_challenge_method = null) {
 		if (!\is_string($response_type) || !\is_string($client_id)
 			|| !\is_string($redirect_uri) || ($state !== null && !\is_string($state))
 		) {
@@ -233,6 +235,8 @@ class PageController extends Controller {
 				$authorizationCode->setClientId($client->getId());
 				$authorizationCode->setUserId($this->userSession->getUser()->getUID());
 				$authorizationCode->resetExpires();
+				$authorizationCode->setCodeChallenge($code_challenge);
+				$authorizationCode->setCodeChallengeMethod($code_challenge_method);
 				$this->authorizationCodeMapper->insert($authorizationCode);
 
 				$result = \urldecode($redirect_uri);

--- a/lib/Exceptions/UnsupportedPkceTransformException.php
+++ b/lib/Exceptions/UnsupportedPkceTransformException.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @author David Christofas <dchristofas@owncloud.com>
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+namespace OCA\OAuth2\Exceptions;
+
+class UnsupportedPkceTransformException extends \Exception {
+}

--- a/lib/Utilities.php
+++ b/lib/Utilities.php
@@ -93,4 +93,9 @@ class Utilities {
 
 		return (\filter_var($redirectUri, FILTER_VALIDATE_URL) !== false);
 	}
+
+	// See https://tools.ietf.org/pdf/rfc7636.pdf#56
+	public static function base64url_encode($data) {
+		return \rtrim(\strtr(\base64_encode($data), '+/', '-_'), '=');
+	}
 }

--- a/tests/Unit/UtilitiesTest.php
+++ b/tests/Unit/UtilitiesTest.php
@@ -80,4 +80,13 @@ class UtilitiesTest extends TestCase {
 	public function testIsValidUrl($expected, $url) {
 		$this->assertEquals($expected, Utilities::isValidUrl($url));
 	}
+
+	public function testBase64url_encode() {
+		$data = \random_bytes(32);
+		$encoded = Utilities::base64url_encode($data);
+		$this->assertEquals(43, \strlen($encoded));
+		$this->assertFalse(\strpos($encoded, '+'));
+		$this->assertFalse(\strpos($encoded, '/'));
+		$this->assertFalse(\strpos($encoded, '='));
+	}
 }


### PR DESCRIPTION
Implemented the PKCE extension according to the [RFC 7636](https://tools.ietf.org/pdf/rfc7636.pdf)

I tested it with the latest desktop client and the Android App and both worked.
It should also still work for clients which do not send the PKCE parameters.
