### PR TITLE
Remove duplicate PHPdoc

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -104,7 +104,6 @@ class Application extends App {
 		}
 		/** @var ClientMapper $mapper */
 		$mapper = \OC::$server->query(ClientMapper::class);
-		/** @var \OCA\OAuth2\Db\Client $client */
 		try {
 			/** @var \OCA\OAuth2\Db\Client $client */
 			$client = $mapper->findByIdentifier($params['client_id']);


### PR DESCRIPTION
This PHPdoc of `\OCA\OAuth2\Db\Client ` was somehow duplicated. `phpstan` started noticing:
```
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
 ------ ----------------------------------------------------- 
  Line   lib/AppInfo/Application.php                          
 ------ ----------------------------------------------------- 
  108    Variable $client in PHPDoc tag @var does not exist.  
 ------ ----------------------------------------------------- 

 [ERROR] Found 1 error                                                          
```

Remove the duplcation.