### PR TITLE
Support setups with user login name != internal UID

### DIFF
--- a/lib/Controller/OAuthApiController.php
+++ b/lib/Controller/OAuthApiController.php
@@ -169,6 +169,11 @@ class OAuthApiController extends ApiController {
 				$this->logger->info('An authorization code has been used by the client "' . $client->getName() . '" to request an access token.', ['app' => $this->appName]);
 
 				$userId = $authorizationCode->getUserId();
+				if (\strstr($userId, ':')) {
+					list($userName, $userId) = \explode(':', $userId, 2);
+				} else {
+					$userName = $userId;
+				}
 				$this->authorizationCodeMapper->delete($authorizationCode);
 
 				$userObj = $this->userManager->get($userId);
@@ -206,6 +211,11 @@ class OAuthApiController extends ApiController {
 				$this->logger->info('A refresh token has been used by the client "' . $client->getName() . '" to request an access token.', ['app' => $this->appName]);
 
 				$userId = $refreshToken->getUserId();
+				if (\strstr($userId, ':')) {
+					list($userName, $userId) = \explode(':', $userId, 2);
+				} else {
+					$userName = $userId;
+				}
 
 				$userObj = $this->userManager->get($userId);
 				if ($userObj === null || !$userObj->isEnabled()) {
@@ -246,7 +256,7 @@ class OAuthApiController extends ApiController {
 				'token_type' => 'Bearer',
 				'expires_in' => AccessToken::EXPIRATION_TIME,
 				'refresh_token' => $refreshToken->getToken(),
-				'user_id' => $userId,
+				'user_id' => $userName,
 				'message_url' => $this->urlGenerator->linkToRouteAbsolute($this->appName . '.page.authorizationSuccessful')
 			]
 		);

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -119,7 +119,7 @@ class PageController extends Controller {
 			);
 		}
 
-		if ($user !== null && $user !== $this->userSession->getUser()->getUID()) {
+		if ($user !== null && $user !== $this->userSession->getUser()->getUserName()) {
 			$logoutUrl = $this->urlGenerator->linkToRouteAbsolute(
 				'oauth2.page.logout', [
 					'user' => $user,
@@ -216,6 +216,15 @@ class PageController extends Controller {
 			return new RedirectResponse(OC_Util::getDefaultPageUrl());
 		}
 
+		$userName = $this->userSession->getUser()->getUserName();
+		$userUID  = $this->userSession->getUser()->getUID();
+
+		if ($userName !== null && $userName !== $userUID) {
+			$userNameAndUid = \implode(':', [ $userName, $userUID ]);
+		} else {
+			$userNameAndUid = $userUID;
+		}
+
 		switch ($response_type) {
 			case 'code':
 				try {
@@ -233,7 +242,7 @@ class PageController extends Controller {
 				$authorizationCode = new AuthorizationCode();
 				$authorizationCode->setCode($code);
 				$authorizationCode->setClientId($client->getId());
-				$authorizationCode->setUserId($this->userSession->getUser()->getUID());
+				$authorizationCode->setUserId($userNameAndUid);
 				$authorizationCode->resetExpires();
 				$authorizationCode->setCodeChallenge($code_challenge);
 				$authorizationCode->setCodeChallengeMethod($code_challenge_method);
@@ -264,7 +273,7 @@ class PageController extends Controller {
 				$accessToken = new AccessToken();
 				$accessToken->setToken($token);
 				$accessToken->setClientId($client->getId());
-				$accessToken->setUserId($this->userSession->getUser()->getUID());
+				$accessToken->setUserId($userNameAndUid);
 				$accessToken->resetExpires();
 				$this->accessTokenMapper->insert($accessToken);
 


### PR DESCRIPTION
Dear Owncloud team,

we use the `user_ldap` backend against Active Directory, and we have it configured with `ldap_expert_uuid_user_attr` = `objectguid` and `ldap_expert_username_attr` blank, thus the internal owncloud IDs are the AD GUIDs, but users log on with their `sAMAccountName`.

This causes a discrepancy in the OAuth login flow, as the user identifier passed along the flow is the user name, that doesn't match with the user UID that all the Desktop, iOS and Android clients expect.

Armed with much desire to have this fixed and with little knowledge of OC internals, I made this adaptation that seem to work well with our use case - but it looks also generic enough to be included upstream.

Thank you for your consideration,