### PR TITLE
Add support for trusted clients

### DIFF
--- a/appinfo/Migrations/Version20201123114127.php
+++ b/appinfo/Migrations/Version20201123114127.php
@@ -1,0 +1,16 @@
+<?php
+namespace OCA\oauth2\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use OCP\Migration\ISchemaMigration;
+
+class Version20201123114127 implements ISchemaMigration {
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+		$table = $schema->getTable("{$prefix}oauth2_clients");
+		if (!$table->hasColumn('trusted')) {
+			$table->addColumn('trusted', Types::BOOLEAN, ['notNull' => true, 'default' => false]);
+		}
+	}
+}

--- a/lib/Commands/AddClient.php
+++ b/lib/Commands/AddClient.php
@@ -70,6 +70,12 @@ class AddClient extends Command {
 				InputArgument::OPTIONAL,
 				'Defines if the redirect url is allowed to use sub domains. Enter true or false',
 				'false'
+			)
+			->addArgument(
+				'trusted',
+				InputArgument::OPTIONAL,
+				'Defines if the client is trusted. Enter true or false',
+				'false'
 			);
 	}
 
@@ -84,8 +90,8 @@ class AddClient extends Command {
 		$id = $input->getArgument('client-id');
 		$secret = $input->getArgument('client-secret');
 		$url = $input->getArgument('redirect-url');
-		/** @var string[]|string|null $allowSubDomains */
 		$allowSubDomains = $input->getArgument('allow-sub-domains');
+		$trusted = $input->getArgument('trusted');
 
 		if (\strlen($id) < 32) {
 			throw new \InvalidArgumentException('The client id should be at least 32 characters long');
@@ -98,6 +104,9 @@ class AddClient extends Command {
 		}
 		if (!\in_array($allowSubDomains, ['true', 'false'])) {
 			throw new \InvalidArgumentException('Please enter true or false for allowed-sub-domains.');
+		}
+		if (!\in_array($trusted, ['true', 'false'])) {
+			throw new \InvalidArgumentException('Please enter true or false for trusted.');
 		}
 		try {
 			// the name should be uniq
@@ -119,7 +128,9 @@ class AddClient extends Command {
 			$client->setRedirectUri($url);
 			$client->setSecret($secret);
 			$allowSubDomains = \filter_var($allowSubDomains, FILTER_VALIDATE_BOOLEAN);
-			$client->setAllowSubdomains($allowSubDomains);
+			$client->setAllowSubdomains((bool)$allowSubDomains);
+			$trusted = \filter_var($trusted, FILTER_VALIDATE_BOOLEAN);
+			$client->setTrusted((bool)$trusted);
 
 			$this->clientMapper->insert($client);
 		}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -59,7 +59,7 @@ class PageController extends Controller {
 	/**
 	 * PageController constructor.
 	 *
-	 * @param string $AppName The app's name.
+	 * @param string $appName The app's name.
 	 * @param IRequest $request The request.
 	 * @param ClientMapper $clientMapper The client mapper.
 	 * @param AuthorizationCodeMapper $authorizationCodeMapper The authorization code mapper.
@@ -97,7 +97,7 @@ class PageController extends Controller {
 	 * @param string $response_type The expected response type.
 	 * @param string $client_id The client identifier.
 	 * @param string $redirect_uri The redirection URI.
-	 * @param string $state The state.
+	 * @param string | null $state The state.
 	 * @param string | null $user
 	 *
 	 * @return TemplateResponse | RedirectResponse The authorize view or the

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -70,7 +70,7 @@ class PageController extends Controller {
 	 * @param IUserManager $userManager
 	 */
 	public function __construct(
-		$AppName,
+		string $appName,
 		IRequest $request,
 		ClientMapper $clientMapper,
 		AuthorizationCodeMapper $authorizationCodeMapper,
@@ -80,7 +80,7 @@ class PageController extends Controller {
 		IUserSession $userSession,
 		IUserManager $userManager
 	) {
-		parent::__construct($AppName, $request);
+		parent::__construct($appName, $request);
 
 		$this->clientMapper = $clientMapper;
 		$this->authorizationCodeMapper = $authorizationCodeMapper;
@@ -113,7 +113,9 @@ class PageController extends Controller {
 		$client_id,
 		$redirect_uri,
 		$state = null,
-		$user = null
+		$user = null,
+		$code_challenge = null,
+		$code_challenge_method = null
 	) {
 		if (!\is_string($response_type) || !\is_string($client_id)
 			|| !\is_string($redirect_uri) || ($state !== null && !\is_string($state))
@@ -183,6 +185,11 @@ class PageController extends Controller {
 			}
 
 			return new RedirectResponse($errorRedirectUri);
+		}
+
+		// trusted clients get their auth code back directly
+		if ($client->getTrusted()) {
+			return $this->generateAuthorizationCode($response_type, $client_id, $redirect_uri, $state, $code_challenge, $code_challenge_method);
 		}
 
 		$logoutUrl = $this->urlGenerator->linkToRouteAbsolute(

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -35,6 +35,7 @@ use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\Template;
+use Rowbot\URL\URL;
 
 class SettingsController extends Controller {
 
@@ -129,6 +130,11 @@ class SettingsController extends Controller {
 		$allowSubdomains = $this->request->getParam('allow_subdomains', null) !== null;
 		$client->setAllowSubdomains($allowSubdomains);
 		$trusted = $this->request->getParam('trusted', null) !== null;
+
+		$rURI = new URL(Utilities::removeWildcardPort($redirectUri));
+		if (($rURI->hostname === 'localhost' || $rURI->hostname === '127.0.0.1') && $trusted) {
+			return $this->sendErrorResponse($this->l10n->t('Cannot set localhost as trusted.'));
+		}
 		$client->setTrusted($trusted);
 
 		$this->clientMapper->insert($client);

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -27,6 +27,7 @@ use OCA\OAuth2\Db\RefreshTokenMapper;
 use OCA\OAuth2\Utilities;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\IL10N;
@@ -98,12 +99,7 @@ class SettingsController extends Controller {
 		$this->urlGenerator = $urlGenerator;
 	}
 
-	/**
-	 * Adds a client.
-	 *
-	 * @return JSONResponse
-	 */
-	public function addClient() {
+	public function addClient(): JSONResponse {
 		$redirectUri = \trim($this->request->getParam('redirect_uri', ''));
 		$name = \trim($this->request->getParam('name', ''));
 		if ($name === '') {
@@ -132,6 +128,8 @@ class SettingsController extends Controller {
 
 		$allowSubdomains = $this->request->getParam('allow_subdomains', null) !== null;
 		$client->setAllowSubdomains($allowSubdomains);
+		$trusted = $this->request->getParam('trusted', null) !== null;
+		$client->setTrusted($trusted);
 
 		$this->clientMapper->insert($client);
 		$this->logger->info('The client "' . $client->getName() . '" has been added.', ['app' => $this->appName]);
@@ -155,9 +153,9 @@ class SettingsController extends Controller {
 	 *
 	 * @return JSONResponse
 	 * @throws DoesNotExistException
-	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+	 * @throws MultipleObjectsReturnedException
 	 */
-	public function deleteClient($id) {
+	public function deleteClient($id): JSONResponse {
 		if (!\is_int($id)) {
 			return $this->sendErrorResponse($this->l10n->t('Client id must be a number'));
 		}
@@ -211,11 +209,7 @@ class SettingsController extends Controller {
 		);
 	}
 
-	/**
-	 * @param string $message
-	 * @return JSONResponse
-	 */
-	private function sendErrorResponse($message) {
+	private function sendErrorResponse(string $message): JSONResponse {
 		return new JSONResponse(
 			[
 				'status' => 'error',

--- a/lib/Db/Client.php
+++ b/lib/Db/Client.php
@@ -32,6 +32,7 @@ use OCP\AppFramework\Db\Entity;
  * @method string getName()
  * @method void setName(string $name)
  * @method boolean getAllowSubdomains()
+ * @method boolean getTrusted()
  */
 class Client extends Entity {
 	protected $identifier;
@@ -39,6 +40,7 @@ class Client extends Entity {
 	protected $redirectUri;
 	protected $name;
 	protected $allowSubdomains;
+	protected $trusted;
 
 	/**
 	 * Client constructor.
@@ -50,17 +52,22 @@ class Client extends Entity {
 		$this->addType('redirect_uri', 'string');
 		$this->addType('name', 'string');
 		$this->addType('allow_subdomains', 'boolean');
+		$this->addType('trusted', 'boolean');
 	}
 
-	/**
-	 * @param boolean $value
-	 */
-	public function setAllowSubdomains($value) {
-		$value = (boolean)$value;
+	public function setAllowSubdomains(bool $value): void {
 		if (\OC::$server->getDatabaseConnection()->getDatabasePlatform() instanceof OraclePlatform) {
-			parent::setter('allowSubdomains', [$value ? 1 : 0]);
+			$this->setter('allowSubdomains', [$value ? 1 : 0]);
 		} else {
-			parent::setter('allowSubdomains', [$value]);
+			$this->setter('allowSubdomains', [$value]);
+		}
+	}
+
+	public function setTrusted(bool $value): void {
+		if (\OC::$server->getDatabaseConnection()->getDatabasePlatform() instanceof OraclePlatform) {
+			$this->setter('trusted', [$value ? 1 : 0]);
+		} else {
+			$this->setter('trusted', [$value]);
 		}
 	}
 }

--- a/lib/Utilities.php
+++ b/lib/Utilities.php
@@ -88,11 +88,15 @@ class Utilities {
 		}
 	}
 
-	public static function isValidUrl($redirectUri): bool {
+	public static function removeWildcardPort($redirectUri): string {
 		if (\strpos($redirectUri, 'http://localhost:*') === 0) {
 			$redirectUri = 'http://localhost' . \substr($redirectUri, 18);
 		}
+		return $redirectUri;
+	}
 
+	public static function isValidUrl($redirectUri): bool {
+		$redirectUri = Utilities::removeWildcardPort($redirectUri);
 		return (\filter_var($redirectUri, FILTER_VALIDATE_URL) !== false);
 	}
 

--- a/templates/client.part.php
+++ b/templates/client.part.php
@@ -1,4 +1,5 @@
 <?php if (isset($_['client'])) {
+	/** @var \OCA\OAuth2\Db\Client $client */
 	$client = $_['client'];
 } ?>
 
@@ -7,11 +8,16 @@
 	<td><?php p($client->getRedirectUri()); ?></td>
 	<td><code class="oauth2-identifier"><?php p($client->getIdentifier()); ?></code></td>
 	<td><code><?php p($client->getSecret()); ?></code></td>
-<?php if ($client->getAllowSubdomains()): ?>
-	<td class="icon-32 icon-checkmark"></td>
-<?php else: ?>
-	<td></td>
-<?php endif; ?>
+	<?php if ($client->getAllowSubdomains()): ?>
+		<td class="icon-32 icon-checkmark"></td>
+	<?php else: ?>
+		<td></td>
+	<?php endif; ?>
+	<?php if ($client->getTrusted()): ?>
+		<td class="icon-32 icon-checkmark"></td>
+	<?php else: ?>
+		<td></td>
+	<?php endif; ?>
 	<td>
 		<button type="button" class="button icon-delete" data-id="<?php p($client->getId()) ?>"></button>
 	</td>

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -46,6 +46,7 @@ if (!empty($_['clients'])) {
 				<th id="headerClientIdentifier" scope="col"><?php p($l->t('Client Identifier')); ?></th>
 				<th id="headerSecret" scope="col"><?php p($l->t('Secret')); ?></th>
 				<th id="headerSubdomains" scope="col"><?php p($l->t('Subdomains allowed')); ?></th>
+				<th id="headerTrusted" scope="col"><?php p($l->t('Trusted client')); ?></th>
 				<th id="headerRemove">&nbsp;</th>
 			</tr>
 		</thead>
@@ -64,6 +65,8 @@ if (!empty($_['clients'])) {
 		<input name="redirect_uri" type="text" placeholder="<?php p($l->t('Redirection URI')); ?>">
 		<input name="allow_subdomains" id="allow_subdomains" type="checkbox" class="checkbox" value="1"/>
 		<label for="allow_subdomains"><?php p($l->t('Allow subdomains'));?></label>
+		<input name="trusted" id="trusted" type="checkbox" class="checkbox" value="0"/>
+		<label for="trusted"><?php p($l->t('Trusted client'));?></label>
 	</form>
 	<button id="oauth2_submit" type="button" class="button"><?php p($l->t('Add')); ?></button>
 	<span id="oauth2_save_msg"></span>

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -65,7 +65,7 @@ if (!empty($_['clients'])) {
 		<input name="redirect_uri" type="text" placeholder="<?php p($l->t('Redirection URI')); ?>">
 		<input name="allow_subdomains" id="allow_subdomains" type="checkbox" class="checkbox" value="1"/>
 		<label for="allow_subdomains"><?php p($l->t('Allow subdomains'));?></label>
-		<input name="trusted" id="trusted" type="checkbox" class="checkbox" value="0"/>
+		<input name="trusted" id="trusted" type="checkbox" class="checkbox" value="1"/>
 		<label for="trusted"><?php p($l->t('Trusted client'));?></label>
 	</form>
 	<button id="oauth2_submit" type="button" class="button"><?php p($l->t('Add')); ?></button>

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -78,7 +78,6 @@ class PageControllerTest extends TestCase {
 		$this->clientMapper = $container->query(ClientMapper::class);
 		$this->clientMapper->deleteAll();
 
-		/** @var Client $client */
 		$client = new Client();
 		$client->setIdentifier($this->identifier);
 		$client->setSecret($this->secret);
@@ -123,137 +122,155 @@ class PageControllerTest extends TestCase {
 		$this->clientMapper->delete($this->client);
 	}
 
-	public function testAuthorize() {
+	public function testAuthorize(): void {
 		// Wrong types
 		$result = $this->controller->authorize(1, 'qwertz', 'abcd', 'state');
-		$this->assertInstanceOf(TemplateResponse::class, $result);
-		$this->assertEquals('authorize-error', $result->getTemplateName());
-		$this->assertEquals(
+		self::assertInstanceOf(TemplateResponse::class, $result);
+		self::assertEquals('authorize-error', $result->getTemplateName());
+		self::assertEquals(
 			['client_name' => null],
 			$result->getParams()
 		);
 
 		$result = $this->controller->authorize('code', 2, 'abcd', 'state');
-		$this->assertInstanceOf(TemplateResponse::class, $result);
-		$this->assertEquals('authorize-error', $result->getTemplateName());
-		$this->assertEquals(
+		self::assertInstanceOf(TemplateResponse::class, $result);
+		self::assertEquals('authorize-error', $result->getTemplateName());
+		self::assertEquals(
 			['client_name' => null],
 			$result->getParams()
 		);
 
 		$result = $this->controller->authorize('code', 'qwertz', 3, 'state');
-		$this->assertInstanceOf(TemplateResponse::class, $result);
-		$this->assertEquals('authorize-error', $result->getTemplateName());
-		$this->assertEquals(
+		self::assertInstanceOf(TemplateResponse::class, $result);
+		self::assertEquals('authorize-error', $result->getTemplateName());
+		self::assertEquals(
 			['client_name' => null],
 			$result->getParams()
 		);
 
 		$result = $this->controller->authorize('code', $this->identifier, \urldecode($this->redirectUri), 4);
-		$this->assertInstanceOf(TemplateResponse::class, $result);
-		$this->assertEquals('authorize-error', $result->getTemplateName());
-		$this->assertEquals(
+		self::assertInstanceOf(TemplateResponse::class, $result);
+		self::assertEquals('authorize-error', $result->getTemplateName());
+		self::assertEquals(
 			['client_name' => null],
 			$result->getParams()
 		);
 
 		// Wrong parameters
 		$result = $this->controller->authorize('code', 'qwertz', 'abcd', 'state');
-		$this->assertInstanceOf(TemplateResponse::class, $result);
-		$this->assertEquals('authorize-error', $result->getTemplateName());
-		$this->assertEquals(
+		self::assertInstanceOf(TemplateResponse::class, $result);
+		self::assertEquals('authorize-error', $result->getTemplateName());
+		self::assertEquals(
 			['client_name' => null],
 			$result->getParams()
 		);
 
 		$result = $this->controller->authorize('qwertz', $this->identifier, \urldecode($this->redirectUri));
-		$this->assertInstanceOf(RedirectResponse::class, $result);
-		$this->assertEquals('https://owncloud.org?error=unsupported_response_type', $result->getRedirectURL());
+		self::assertInstanceOf(RedirectResponse::class, $result);
+		self::assertEquals('https://owncloud.org?error=unsupported_response_type', $result->getRedirectURL());
 
 		$result = $this->controller->authorize('code', $this->identifier, \urldecode('https://www.example.org'));
-		$this->assertInstanceOf(TemplateResponse::class, $result);
-		$this->assertEquals('authorize-error', $result->getTemplateName());
-		$this->assertEquals(
+		self::assertInstanceOf(TemplateResponse::class, $result);
+		self::assertEquals('authorize-error', $result->getTemplateName());
+		self::assertEquals(
 			['client_name' => $this->name],
 			$result->getParams()
 		);
 
 		$result = $this->controller->authorize('code', $this->identifier, \urldecode($this->redirectUri));
-		$this->assertInstanceOf(TemplateResponse::class, $result);
-		$this->assertEquals('authorize', $result->getTemplateName());
-		$this->assertEquals(['client_name' => $this->name, 'logout_url' => null,
+		self::assertInstanceOf(TemplateResponse::class, $result);
+		self::assertEquals('authorize', $result->getTemplateName());
+		self::assertEquals(['client_name' => $this->name, 'logout_url' => null,
 			'current_user' => '<strong>Alice</strong>'], $result->getParams());
 	}
 
-	public function testGenerateAuthorizationCode() {
+	public function testGenerateAuthorizationCode(): void {
 		// Wrong types
 		$result = $this->controller->generateAuthorizationCode(1, 'qwertz', 'abcd', 'state');
-		$this->assertInstanceOf(RedirectResponse::class, $result);
-		$this->assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
+		self::assertInstanceOf(RedirectResponse::class, $result);
+		self::assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
 
 		$result = $this->controller->generateAuthorizationCode('code', 2, 'abcd', 'state');
-		$this->assertInstanceOf(RedirectResponse::class, $result);
-		$this->assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
+		self::assertInstanceOf(RedirectResponse::class, $result);
+		self::assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
 
 		$result = $this->controller->generateAuthorizationCode('code', 'qwertz', 3, 'state');
-		$this->assertInstanceOf(RedirectResponse::class, $result);
-		$this->assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
+		self::assertInstanceOf(RedirectResponse::class, $result);
+		self::assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
 
 		$result = $this->controller->generateAuthorizationCode('code', $this->identifier, \urldecode($this->redirectUri), 4);
-		$this->assertInstanceOf(RedirectResponse::class, $result);
-		$this->assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
+		self::assertInstanceOf(RedirectResponse::class, $result);
+		self::assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
 
 		// Wrong parameters
 		$result = $this->controller->generateAuthorizationCode('code', 'qwertz', 'abcd', 'state');
-		$this->assertInstanceOf(RedirectResponse::class, $result);
-		$this->assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
+		self::assertInstanceOf(RedirectResponse::class, $result);
+		self::assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
 
 		$result = $this->controller->generateAuthorizationCode('qwertz', $this->identifier, \urldecode($this->redirectUri));
-		$this->assertInstanceOf(RedirectResponse::class, $result);
-		$this->assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
+		self::assertInstanceOf(RedirectResponse::class, $result);
+		self::assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
 
 		$result = $this->controller->generateAuthorizationCode('code', $this->identifier, \urldecode('https://www.example.org'));
-		$this->assertInstanceOf(RedirectResponse::class, $result);
-		$this->assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
+		self::assertInstanceOf(RedirectResponse::class, $result);
+		self::assertEquals(OC_Util::getDefaultPageUrl(), $result->getRedirectURL());
 
-		$this->assertCount(0, $this->authorizationCodeMapper->findAll());
+		self::assertCount(0, $this->authorizationCodeMapper->findAll());
 		$result = $this->controller->generateAuthorizationCode('code', $this->identifier, \urldecode($this->redirectUri));
-		$this->assertInstanceOf(RedirectResponse::class, $result);
-		$this->assertCount(1, $this->authorizationCodeMapper->findAll());
-		list($url, $query) = \explode('?', $result->getRedirectURL());
-		$this->assertEquals($url, $this->redirectUri);
+		self::assertInstanceOf(RedirectResponse::class, $result);
+		self::assertCount(1, $this->authorizationCodeMapper->findAll());
+		[$url, $query] = \explode('?', $result->getRedirectURL());
+		self::assertEquals($url, $this->redirectUri);
 		\parse_str($query, $parameters);
-		$this->assertTrue(\array_key_exists('code', $parameters));
+		self::assertTrue(\array_key_exists('code', $parameters));
 		$expected = \time() + AuthorizationCode::EXPIRATION_TIME;
 		/** @var AuthorizationCode $authorizationCode */
 		$authorizationCode = $this->authorizationCodeMapper->findByCode($parameters['code']);
-		$this->assertEqualsWithDelta($expected, $authorizationCode->getExpires(), 1);
-		$this->assertEquals('Alice', $authorizationCode->getUserId());
-		$this->assertEquals($this->client->getId(), $authorizationCode->getClientId());
+		self::assertEqualsWithDelta($expected, $authorizationCode->getExpires(), 1);
+		self::assertEquals('Alice', $authorizationCode->getUserId());
+		self::assertEquals($this->client->getId(), $authorizationCode->getClientId());
 		$this->authorizationCodeMapper->delete($this->authorizationCodeMapper->findByCode($parameters['code']));
 
-		$this->assertCount(0, $this->authorizationCodeMapper->findAll());
+		self::assertCount(0, $this->authorizationCodeMapper->findAll());
 		$result = $this->controller->generateAuthorizationCode('code', $this->identifier, \urldecode($this->redirectUri), 'testingState');
-		$this->assertInstanceOf(RedirectResponse::class, $result);
-		$this->assertCount(1, $this->authorizationCodeMapper->findAll());
-		list($url, $query) = \explode('?', $result->getRedirectURL());
-		$this->assertEquals($url, $this->redirectUri);
+		self::assertInstanceOf(RedirectResponse::class, $result);
+		self::assertCount(1, $this->authorizationCodeMapper->findAll());
+		[$url, $query] = \explode('?', $result->getRedirectURL());
+		self::assertEquals($url, $this->redirectUri);
 		\parse_str($query, $parameters);
-		$this->assertTrue(\array_key_exists('state', $parameters));
-		$this->assertEquals('testingState', $parameters['state']);
-		$this->assertTrue(\array_key_exists('code', $parameters));
+		self::assertTrue(\array_key_exists('state', $parameters));
+		self::assertEquals('testingState', $parameters['state']);
+		self::assertTrue(\array_key_exists('code', $parameters));
 		$expected = \time() + 600;
 		/** @var AuthorizationCode $authorizationCode */
 		$authorizationCode = $this->authorizationCodeMapper->findByCode($parameters['code']);
-		$this->assertEqualsWithDelta($expected, $authorizationCode->getExpires(), 1);
-		$this->assertEquals('Alice', $authorizationCode->getUserId());
-		$this->assertEquals($this->client->getId(), $authorizationCode->getClientId());
+		self::assertEqualsWithDelta($expected, $authorizationCode->getExpires(), 1);
+		self::assertEquals('Alice', $authorizationCode->getUserId());
+		self::assertEquals($this->client->getId(), $authorizationCode->getClientId());
 		$this->authorizationCodeMapper->delete($this->authorizationCodeMapper->findByCode($parameters['code']));
 	}
 
-	public function testAuthorizationSuccessful() {
+	public function testAuthorizationSuccessful(): void {
 		$result = $this->controller->authorizationSuccessful();
-		$this->assertInstanceOf(TemplateResponse::class, $result);
-		$this->assertEquals('authorization-successful', $result->getTemplateName());
+		self::assertInstanceOf(TemplateResponse::class, $result);
+		self::assertEquals('authorization-successful', $result->getTemplateName());
+	}
+
+	public function testTrustedClient(): void {
+		$identifier = 'trusted-client';
+		// add trusted client
+		$client = new Client();
+		$client->setIdentifier($identifier);
+		$client->setSecret($this->secret);
+		$client->setRedirectUri($this->redirectUri);
+		$client->setName('trusted client for testing');
+		$client->setAllowSubdomains(false);
+		$client->setTrusted(true);
+		$this->client = $this->clientMapper->insert($client);
+
+		/** @var RedirectResponse $result */
+		$result = $this->controller->authorize('code', $identifier, \urldecode($this->redirectUri));
+		self::assertInstanceOf(RedirectResponse::class, $result);
+		self::assertStringStartsWith($this->redirectUri . '?code=', $result->getRedirectURL());
 	}
 }

--- a/tests/acceptance/features/bootstrap/Oauth2Context.php
+++ b/tests/acceptance/features/bootstrap/Oauth2Context.php
@@ -29,8 +29,6 @@ use Page\Oauth2OnPersonalSecuritySettingsPage;
 use PHPUnit\Framework\Assert;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\WebDavHelper;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
 use Page\Oauth2AdminSettingsPage;
 use TestHelpers\SetupHelper;
 
@@ -241,9 +239,9 @@ class Oauth2Context extends RawMinkContext implements Context {
 	 * @When the client app requests an access token
 	 * @Given the client app has requested an access token
 	 *
-	 * @param string $refreshToken if set the `grant_type` `refresh_token`
-	 *                             will be used with the given refresh token
-	 *                             to request a new access token
+	 * @param string|null $refreshToken if set the `grant_type` `refresh_token`
+	 *                                  will be used with the given refresh token
+	 *                                  to request a new access token
 	 * @param string|null $clientId
 	 * @param string|null $clientSecret
 	 *
@@ -297,7 +295,7 @@ class Oauth2Context extends RawMinkContext implements Context {
 	 * @When the client app requests an access token with the new client-id and client-secret
 	 * @Given the client app has requested an access token with the new client-id and client-secret
 	 *
-	 * @param string $refreshToken see clientAppRequestsAccessToken()
+	 * @param string|null $refreshToken see clientAppRequestsAccessToken()
 	 *
 	 * @return void
 	 */
@@ -551,11 +549,9 @@ class Oauth2Context extends RawMinkContext implements Context {
 	/**
 	 * @AfterScenario @webUI
 	 *
-	 * @param AfterScenarioScope $scope
-	 *
 	 * @return void
 	 */
-	public function after(AfterScenarioScope $scope) {
+	public function after() {
 		$this->featureContext->authContext->aNewBrowserSessionForHasBeenStarted(
 			$this->featureContext->getAdminUsername()
 		);

--- a/tests/acceptance/features/lib/Oauth2AdminSettingsPage.php
+++ b/tests/acceptance/features/lib/Oauth2AdminSettingsPage.php
@@ -39,16 +39,16 @@ class Oauth2AdminSettingsPage extends OwncloudPage {
 	/**
 	 *
 	 * @param string $appName
-	 * @param string $redirctionUri
+	 * @param string $redirectionUri
 	 * @param boolean $allowSubdomains
 	 *
+	 * @return void
 	 * @throws ElementNotFoundException
 	 *
-	 * @return void
 	 */
-	public function addClient($appName, $redirctionUri, $allowSubdomains = false) {
+	public function addClient($appName, $redirectionUri, $allowSubdomains = false) {
 		$this->fillField($this->oauthAppNameInputId, $appName);
-		$this->fillField($this->oauthRedirectionUriInputId, $redirctionUri);
+		$this->fillField($this->oauthRedirectionUriInputId, $redirectionUri);
 		if ($allowSubdomains === true) {
 			$allowSubdomainsCheckBox = $this->find(
 				"xpath",
@@ -81,7 +81,7 @@ class Oauth2AdminSettingsPage extends OwncloudPage {
 	 *
 	 * @throws ElementNotFoundException
 	 *
-	 * @return string[] arrray with keys name,redirection_uri,client_id,client_secret,id
+	 * @return string[] array with keys name,redirection_uri,client_id,client_secret,id
 	 */
 	public function getClientInformationByName($name) {
 		$xpath = \sprintf($this->clientRowByNameXpath, $name);
@@ -97,7 +97,7 @@ class Oauth2AdminSettingsPage extends OwncloudPage {
 		$result['redirection_uri'] = $tds[1]->getText();
 		$result['client_id'] = $tds[2]->getText();
 		$result['client_secret'] = $tds[3]->getText();
-		$result['id'] = (int) $tds[5]->find("xpath", "/button")->getAttribute("data-id");
+		$result['id'] = (int) $tds[6]->find("xpath", "/button")->getAttribute("data-id");
 
 		return $result;
 	}


### PR DESCRIPTION
I'm reopening https://github.com/owncloud/oauth2/pull/275 because setting a client as trusted makes sense in certain situations like for web clients.

This change introduces the options to set a client as trusted and therefor skip the consent step.

https://auth0.com/docs/authorization/user-consent-and-third-party-applications#skip-consent-for-first-party-applications