### PR TITLE
Fix user lookup in authmodule

### DIFF
--- a/lib/AuthModule.php
+++ b/lib/AuthModule.php
@@ -113,7 +113,11 @@ class AuthModule implements IAuthModule {
 
 		/** @var \OCP\IUserManager $userManager */
 		$userManager = $container->query('UserManager');
-		return $userManager->get($accessToken->getUserId());
+		$userId = $accessToken->getUserId();
+		if (\strstr($userId, ':')) {
+			list($userName, $userId) = \explode(':', $userId, 2);
+		}
+		return $userManager->get($userId);
 	}
 
 	protected function tokenCanBeHandledByOpenIDConnect(): bool {


### PR DESCRIPTION
In case the userName and userId are not matching the authToken consists
of both as a concatenated string. The user lookup in the AuthModule used
the full userId value from the authToken, while it should only check the
userId-part from the DB value.

## Example auth token in DB, where userId and userName are not matching (= "LDAP use case")
```
+------+------------------------------------------------------------------+-----------+-----------------------------------------------+------------+
| id   | token                                                            | client_id | user_id                                       | expires    |
+------+------------------------------------------------------------------+-----------+-----------------------------------------------+------------+
| 2363 | ************************* |        29 | bkulmann:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx | 1633523318 |
+------+------------------------------------------------------------------+-----------+-----------------------------------------------+------------+

## origin of the bug
The concatenated version of the `userId` access token field was introduced in https://github.com/owncloud/oauth2/pull/286 - apparently the part in the `AuthModule` was missed in that PR. This PR fixes it.