### PR TITLE
[Tests-Only] enforce strict type checking in acceptace tests code

### DIFF
--- a/tests/acceptance/features/bootstrap/Oauth2Context.php
+++ b/tests/acceptance/features/bootstrap/Oauth2Context.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *

--- a/tests/acceptance/features/lib/Oauth2AdminSettingsPage.php
+++ b/tests/acceptance/features/lib/Oauth2AdminSettingsPage.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * ownCloud

--- a/tests/acceptance/features/lib/Oauth2AuthRequestPage.php
+++ b/tests/acceptance/features/lib/Oauth2AuthRequestPage.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *

--- a/tests/acceptance/features/lib/Oauth2OnPersonalSecuritySettingsPage.php
+++ b/tests/acceptance/features/lib/Oauth2OnPersonalSecuritySettingsPage.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * ownCloud


### PR DESCRIPTION
Related https://github.com/owncloud/QA/issues/694
- add strict type checking on acceptace test code

**note** this PR was generated by a automated script