### PR TITLE
use userid on api calls, show username in login form

### DIFF
--- a/lib/Controller/OAuthApiController.php
+++ b/lib/Controller/OAuthApiController.php
@@ -177,11 +177,12 @@ class OAuthApiController extends ApiController {
 				$this->logger->info('An authorization code has been used by the client "' . $client->getName() . '" to request an access token.', ['app' => $this->appName]);
 
 				$userId = $authorizationCode->getUserId();
+
+				// strip off username if it exists
 				if (\strstr($userId, ':')) {
-					list($userName, $userId) = \explode(':', $userId, 2);
-				} else {
-					$userName = $userId;
+					list(, $userId) = \explode(':', $userId, 2);
 				}
+
 				$this->authorizationCodeMapper->delete($authorizationCode);
 
 				$userObj = $this->userManager->get($userId);
@@ -219,10 +220,10 @@ class OAuthApiController extends ApiController {
 				$this->logger->info('A refresh token has been used by the client "' . $client->getName() . '" to request an access token.', ['app' => $this->appName]);
 
 				$userId = $refreshToken->getUserId();
+
+				// strip off username if it exists
 				if (\strstr($userId, ':')) {
-					list($userName, $userId) = \explode(':', $userId, 2);
-				} else {
-					$userName = $userId;
+					list(, $userId) = \explode(':', $userId, 2);
 				}
 
 				$userObj = $this->userManager->get($userId);
@@ -264,7 +265,7 @@ class OAuthApiController extends ApiController {
 				'token_type' => 'Bearer',
 				'expires_in' => AccessToken::EXPIRATION_TIME,
 				'refresh_token' => $refreshToken->getToken(),
-				'user_id' => $userName,
+				'user_id' => $userId,
 				'message_url' => $this->urlGenerator->linkToRouteAbsolute($this->appName . '.page.authorizationSuccessful')
 			]
 		);

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -332,9 +332,9 @@ class PageController extends Controller {
 	 * @return RedirectResponse | TemplateResponse
 	 */
 	public function logout(
-		$user, 
-		$response_type, 
-		$client_id, 
+		$user,
+		$response_type,
+		$client_id,
 		$redirect_uri,
 		$state = null,
 		$code_challenge = null,

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -39,8 +39,6 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Util;
 
-use function PHPSTORM_META\map;
-
 class PageController extends Controller {
 
 	/** @var ClientMapper */

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -129,13 +129,6 @@ class PageController extends Controller {
 			);
 		}
 
-		$userObj = $this->userManager->get($user);
-		if ($userObj !== null) {
-				$userName = $userObj->getUserName();
-		} else {
-			$userName = $user;
-		}
-
 		if ($this->isDifferentUser($user)) {
 			$logoutUrl = $this->urlGenerator->linkToRouteAbsolute(
 				'oauth2.page.logout',

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -140,7 +140,7 @@ class PageController extends Controller {
 			$logoutUrl = $this->urlGenerator->linkToRouteAbsolute(
 				'oauth2.page.logout',
 				[
-					'user' => $userName,
+					'user' => $user,
 					'requesttoken' => Util::callRegister(),
 					'response_type' => $response_type,
 					'client_id' => $client_id,
@@ -368,7 +368,7 @@ class PageController extends Controller {
 			'core.login.showLoginForm',
 			[
 				'user' => $userName,
-				'redirect_url' => $redirectUrl
+				'redirect_url' => \urlencode($redirectUrl)
 			]
 		));
 	}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -129,19 +129,11 @@ class PageController extends Controller {
 			);
 		}
 
-		// look up username so we can fill the login field for the end user
-		$userObj = $this->userManager->get($user);
-		if ($userObj !== null) {
-			$userName = $userObj->getUserName();
-		} else {
-			$userName = $user;
-		}
-
 		if ($this->isDifferentUser($user)) {
 			$logoutUrl = $this->urlGenerator->linkToRouteAbsolute(
 				'oauth2.page.logout',
 				[
-					'user' => $userName,
+					'user' => $user,
 					'requesttoken' => Util::callRegister(),
 					'response_type' => $response_type,
 					'client_id' => $client_id,
@@ -203,7 +195,7 @@ class PageController extends Controller {
 		$logoutUrl = $this->urlGenerator->linkToRouteAbsolute(
 			'oauth2.page.logout',
 			[
-				'user' => $userName,
+				'user' => $user,
 				'requesttoken' => Util::callRegister(),
 				'response_type' => $response_type,
 				'client_id' => $client_id,

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -39,6 +39,8 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Util;
 
+use function PHPSTORM_META\map;
+
 class PageController extends Controller {
 
 	/** @var ClientMapper */
@@ -138,7 +140,9 @@ class PageController extends Controller {
 					'response_type' => $response_type,
 					'client_id' => $client_id,
 					'redirect_uri' => \urlencode($redirect_uri),
-					'state' => $state
+					'state' => $state,
+					'code_challenge' => $code_challenge,
+					'code_challenge_method' => $code_challenge_method
 				]
 			);
 			$currentUser = $this->userSession->getUser();
@@ -200,7 +204,9 @@ class PageController extends Controller {
 				'response_type' => $response_type,
 				'client_id' => $client_id,
 				'redirect_uri' => \urlencode($redirect_uri),
-				'state' => $state
+				'state' => $state,
+				'code_challenge' => $code_challenge,
+				'code_challenge_method' => $code_challenge_method
 			]
 		);
 		$currentUser = $this->userSession->getUser();
@@ -327,7 +333,14 @@ class PageController extends Controller {
 	 * @param string | null $state
 	 * @return RedirectResponse | TemplateResponse
 	 */
-	public function logout($user, $response_type, $client_id, $redirect_uri, $state = null) {
+	public function logout(
+		$user, 
+		$response_type, 
+		$client_id, 
+		$redirect_uri,
+		$state = null,
+		$code_challenge = null,
+		$code_challenge_method = null) {
 		if (!\is_string($response_type) || !\is_string($client_id)
 			|| !\is_string($redirect_uri) || ($state !== null && !\is_string($state))
 		) {
@@ -345,7 +358,9 @@ class PageController extends Controller {
 			'client_id' => $client_id,
 			'redirect_uri' => $redirect_uri,
 			'state' => $state,
-			'user' => $user
+			'user' => $user,
+			'code_challenge' => $code_challenge,
+			'code_challenge_method' => $code_challenge_method 
 		]);
 
 		// look up username so we can fill the login field for the end user

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -351,16 +351,16 @@ class PageController extends Controller {
 		// look up username so we can fill the login field for the end user
 		$userObj = $this->userManager->get($user);
 		if ($userObj !== null) {
-			$userName = $userObj->getUserName();
+			$loginHint = $userObj->getUserName();
 		} else {
-			$userName = $user;
+			$loginHint = $user;
 		}
 
 		// redirect the browser to the login page and set the redirect_url to the authorize page of oauth2
 		return new RedirectResponse($this->urlGenerator->linkToRouteAbsolute(
 			'core.login.showLoginForm',
 			[
-				'user' => $userName,
+				'user' => $loginHint,
 				'redirect_url' => \urlencode($redirectUrl)
 			]
 		));

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -137,7 +137,7 @@ class PageController extends Controller {
 			$userName = $user;
 		}
 
-		if ($user !== null && $user !== $this->userSession->getUser()->getUID()) {
+		if ($this->isDifferentUser($user)) {
 			$logoutUrl = $this->urlGenerator->linkToRouteAbsolute(
 				'oauth2.page.logout',
 				[
@@ -396,5 +396,20 @@ class PageController extends Controller {
 		$userId = Util::sanitizeHTML($userId);
 		$escapedDisplayName = Util::sanitizeHTML($displayName);
 		return "<span class='hasTooltip' data-original-title='$userId'><strong>$escapedDisplayName</strong></span>";
+	}
+
+	/**
+	 * @param string $userId
+	 * @return bool
+	 */
+	private function isDifferentUser($userId) {
+	        if (empty($userId)) {
+	                return false;
+	        }
+	        $userObj = $this->userManager->get($userId);
+	        if ($userObj === null) {
+	                return true;
+	        }
+	        return $userObj->getUID() !== $this->userSession->getUser()->getUID();
 	}
 }

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -338,7 +338,8 @@ class PageController extends Controller {
 		$redirect_uri,
 		$state = null,
 		$code_challenge = null,
-		$code_challenge_method = null) {
+		$code_challenge_method = null
+	) {
 		if (!\is_string($response_type) || !\is_string($client_id)
 			|| !\is_string($redirect_uri) || ($state !== null && !\is_string($state))
 		) {
@@ -358,7 +359,7 @@ class PageController extends Controller {
 			'state' => $state,
 			'user' => $user,
 			'code_challenge' => $code_challenge,
-			'code_challenge_method' => $code_challenge_method 
+			'code_challenge_method' => $code_challenge_method
 		]);
 
 		// look up username so we can fill the login field for the end user

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -202,7 +202,7 @@ class PageController extends Controller {
 		$logoutUrl = $this->urlGenerator->linkToRouteAbsolute(
 			'oauth2.page.logout',
 			[
-				'user' => $userName,
+				'user' => $user,
 				'requesttoken' => Util::callRegister(),
 				'response_type' => $response_type,
 				'client_id' => $client_id,

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -395,13 +395,13 @@ class PageController extends Controller {
 	 * @return bool
 	 */
 	private function isDifferentUser($userId) {
-	        if (empty($userId)) {
-	                return false;
-	        }
-	        $userObj = $this->userManager->get($userId);
-	        if ($userObj === null) {
-	                return true;
-	        }
-	        return $userObj->getUID() !== $this->userSession->getUser()->getUID();
+		if (empty($userId)) {
+				return false;
+		}
+		$userObj = $this->userManager->get($userId);
+		if ($userObj === null) {
+				return true;
+		}
+		return $userObj->getUID() !== $this->userSession->getUser()->getUID();
 	}
 }

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -99,6 +99,8 @@ class PageController extends Controller {
 	 * @param string $redirect_uri The redirection URI.
 	 * @param string | null $state The state.
 	 * @param string | null $user The user id
+	 * @param string $code_challenge | null The PKCE code challenge.
+	 * @param string $code_challenge_method | null The PKCE code challenge method.
 	 *
 	 * @return TemplateResponse | RedirectResponse The authorize view or the
 	 * authorize-error view with a redirection to the
@@ -329,6 +331,8 @@ class PageController extends Controller {
 	 * @param string $client_id
 	 * @param string $redirect_uri
 	 * @param string | null $state
+	 * @param string $code_challenge | null The PKCE code challenge.
+	 * @param string $code_challenge_method | null The PKCE code challenge method.
 	 * @return RedirectResponse | TemplateResponse
 	 */
 	public function logout(

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -129,11 +129,18 @@ class PageController extends Controller {
 			);
 		}
 
+		$userObj = $this->userManager->get($user);
+		if ($userObj !== null) {
+				$userName = $userObj->getUserName();
+		} else {
+			$userName = $user;
+		}
+
 		if ($this->isDifferentUser($user)) {
 			$logoutUrl = $this->urlGenerator->linkToRouteAbsolute(
 				'oauth2.page.logout',
 				[
-					'user' => $user,
+					'user' => $userName,
 					'requesttoken' => Util::callRegister(),
 					'response_type' => $response_type,
 					'client_id' => $client_id,
@@ -195,7 +202,7 @@ class PageController extends Controller {
 		$logoutUrl = $this->urlGenerator->linkToRouteAbsolute(
 			'oauth2.page.logout',
 			[
-				'user' => $user,
+				'user' => $userName,
 				'requesttoken' => Util::callRegister(),
 				'response_type' => $response_type,
 				'client_id' => $client_id,


### PR DESCRIPTION
fixes https://github.com/owncloud/oauth2/issues/326 by partly reverting https://github.com/owncloud/oauth2/pull/286/files#diff-c88f37beed53f2aeb9db529d2af61368ae49ec6052aa091a062023ae9cfcc670L249-R259 and filling the login form with the login name in the web ui.

The userid should always be used on the api. Clients should use the displayname or email properties that can be accessed via the ocs api.