### PR TITLE
Fill login_hint with username

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -24,13 +24,13 @@ $(document).ready(function(){
 		var data = $("data[key='oauth2']");
 		var msg = t('oauth2', 'The application "{app}" is requesting access to your account. To authorize it, please log in first.', {app : data.attr('client')});
 		$loginMessage.parent().append('<div class="warning"><div class="icon-info-white" />'+msg+'</div>');
-		var user = data.attr('user');
-		if (user) {
+		var login_hint = data.attr('login_hint');
+		if (login_hint) {
+			$('#user')
+				.val(login_hint);
 			$('#password')
 				.val('')
 				.get(0).focus();
-			$('#user')
-				.val(user);
 		}
 	}
 });

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -117,7 +117,7 @@ class Application extends App {
 				if ($u !== null) {
 					$data['login_hint'] = $u->getUserName();
 				}
-				if (!\is_string($data['login_hint']) || $data['login_hint'] === '') {
+				if (!isset($data['login_hint']) || !\is_string($data['login_hint']) || $data['login_hint'] === '') {
 					$data['login_hint'] = $params['user'];
 				}
 			}

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -113,7 +113,7 @@ class Application extends App {
 			\OCP\Util::addStyle('oauth2', 'login');
 			$data = ['key' => 'oauth2', 'client' => $client->getName()];
 			if (isset($params['user'])) {
-				$data['user'] = $params['user'];
+				$data['login_hint'] = $params['user'];
 			}
 			\OCP\Util::addHeader('data', $data);
 		} catch (DoesNotExistException $ex) {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -113,7 +113,13 @@ class Application extends App {
 			\OCP\Util::addStyle('oauth2', 'login');
 			$data = ['key' => 'oauth2', 'client' => $client->getName()];
 			if (isset($params['user'])) {
-				$data['login_hint'] = $params['user'];
+				$u = \OC::$server->getUserManager()->get($params['user']);
+				if ($u !== null) {
+					$data['login_hint'] = $u->getUserName();
+				}
+				if (!\is_string($data['login_hint']) || $data['login_hint'] === '') {
+					$data['login_hint'] = $params['user'];
+				}
 			}
 			\OCP\Util::addHeader('data', $data);
 		} catch (DoesNotExistException $ex) {


### PR DESCRIPTION
The oauth2 app uses js to fill the login with the user from the redirect url. Why exactly I don't know. The LoginController in core already picks up a `user` parameter and fills the login form username with it. AFAICT the code picks up the user from the redirect url. Who knows where that is used.

In any case this PR looks up the user and uses the username instead of the userid. Similar to https://github.com/owncloud/core/pull/39870

