### PR TITLE
[WIP] Add option to invalidate tokens on user logout

### DIFF
--- a/appinfo/Migrations/Version20220525140622.php
+++ b/appinfo/Migrations/Version20220525140622.php
@@ -1,0 +1,19 @@
+<?php
+namespace OCA\oauth2\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use OCP\Migration\ISchemaMigration;
+
+class Version20220525140622 implements ISchemaMigration {
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+		$table = $schema->getTable("{$prefix}oauth2_clients");
+		if (!$table->hasColumn('invalidate_on_logout')) {
+			$table->addColumn('invalidate_on_logout', Types::BOOLEAN, [
+				'notnull' => true,
+				'default' => false,
+			]);
+		}
+	}
+}

--- a/js/settings-admin.js
+++ b/js/settings-admin.js
@@ -38,6 +38,7 @@ $(document).ready(function () {
 					$('#oauth2 input[name="name"]').val('');
 					$('#oauth2 input[name="redirect_uri"]').val('');
 					$('#oauth2 input[name="allow_subdomains"]').prop('checked', false);
+					$('#oauth2 input[name="invalidate_on_logout"]').prop('checked', false);
 				}
 			}
 		);

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -57,7 +57,9 @@ class Application extends App {
 				$c->query('OCA\OAuth2\Db\AuthorizationCodeMapper'),
 				$c->query('OCA\OAuth2\Db\AccessTokenMapper'),
 				$c->query('OCA\OAuth2\Db\RefreshTokenMapper'),
+				$c->query('OCA\OAuth2\Db\ClientMapper'),
 				$c->query('Logger'),
+				\OC::$server->getUserSession(),
 				$c->query('AppName')
 			);
 		});

--- a/lib/Commands/AddClient.php
+++ b/lib/Commands/AddClient.php
@@ -84,6 +84,12 @@ class AddClient extends Command {
 				'Trust the client even if the redirect-url is localhost.',
 				'false'
 			)
+			->addArgument(
+				'invalidate-on-logout',
+				InputArgument::OPTIONAL,
+				'Invalidate the oauth token when logging out of the ownCloud web client',
+				'false'
+			)
 		;
 	}
 
@@ -101,6 +107,7 @@ class AddClient extends Command {
 		$allowSubDomains = $input->getArgument('allow-sub-domains');
 		$trusted = $input->getArgument('trusted');
 		$forceTrust = $input->getArgument('force-trust');
+		$invalidateOnLogout = $input->getArgument('invalidate-on-logout');
 
 		if (\strlen($id) < 32) {
 			throw new \InvalidArgumentException('The client id should be at least 32 characters long');
@@ -116,6 +123,9 @@ class AddClient extends Command {
 		}
 		if (!\in_array($trusted, ['true', 'false'])) {
 			throw new \InvalidArgumentException('Please enter true or false for trusted.');
+		}
+		if (!\in_array($invalidateOnLogout, ['true', 'false'])) {
+			throw new \InvalidArgumentException('Please enter true or false for invalidate-on-logout.');
 		}
 		try {
 			// the name should be uniq
@@ -139,6 +149,7 @@ class AddClient extends Command {
 			$allowSubDomains = \filter_var($allowSubDomains, FILTER_VALIDATE_BOOLEAN);
 			$client->setAllowSubdomains((bool)$allowSubDomains);
 			$trusted = \filter_var($trusted, FILTER_VALIDATE_BOOLEAN);
+			$invalidateOnLogout = \filter_var($invalidateOnLogout, FILTER_VALIDATE_BOOLEAN);
 			$forceTrust = \filter_var($forceTrust, FILTER_VALIDATE_BOOLEAN);
 			$rURI = new URL(Utilities::removeWildcardPort($url));
 			if ($trusted && !$forceTrust && ($rURI->hostname === 'localhost' || $rURI->hostname === '127.0.0.1')) {
@@ -146,6 +157,7 @@ class AddClient extends Command {
 				return 1;
 			}
 			$client->setTrusted((bool)$trusted);
+			$client->setInvalidateOnLogout((bool)$invalidateOnLogout);
 
 			$this->clientMapper->insert($client);
 		}

--- a/lib/Commands/ListClients.php
+++ b/lib/Commands/ListClients.php
@@ -64,6 +64,7 @@ class ListClients extends Base {
 				'client-secret' => $client->getSecret(),
 				'allow-sub-domains' => $client->getAllowSubdomains(),
 				'trusted' => $client->getTrusted(),
+				'invalidate-on-logout' => $client->getInvalidateOnLogout(),
 			];
 		}
 		parent::writeArrayInOutputFormat($input, $output, $clientsOutput, self::DEFAULT_OUTPUT_PREFIX, true);

--- a/lib/Commands/ModifyClient.php
+++ b/lib/Commands/ModifyClient.php
@@ -53,7 +53,7 @@ class ModifyClient extends Command {
 			->addArgument(
 				'key',
 				InputArgument::REQUIRED,
-				'Key to be changed. Valid keys are : name, client-id, client-secret, redirect-url, allow-sub-domains, trusted'
+				'Key to be changed. Valid keys are : name, client-id, client-secret, redirect-url, allow-sub-domains, trusted, invalidate-on-logout'
 			)
 			->addArgument(
 				'value',
@@ -89,6 +89,7 @@ class ModifyClient extends Command {
 			'redirect-url' => 'setRedirectUri',
 			'allow-sub-domains' => 'setAllowSubdomains',
 			'trusted' => 'setTrusted',
+			'invalidate-on-logout' => 'setInvalidateOnLogout',
 		];
 
 		if (!\array_key_exists($key, $funcMapper)) {
@@ -111,8 +112,11 @@ class ModifyClient extends Command {
 		if ($key === 'trusted' && !\in_array($value, ['true', 'false'])) {
 			throw new \InvalidArgumentException('Please enter true or false for trusted.');
 		}
+		if ($key === 'invalidate-on-logout' && !\in_array($value, ['true', 'false'])) {
+			throw new \InvalidArgumentException('Please enter true or false for invalidate-on-logout.');
+		}
 
-		if ($key === 'trusted' || $key == 'allow-sub-domains') {
+		if ($key === 'trusted' || $key == 'allow-sub-domains' || $key == 'invalidate-on-logout') {
 			$value = \filter_var($value, FILTER_VALIDATE_BOOLEAN);
 		}
 

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -354,7 +354,7 @@ class PageController extends Controller {
 			);
 		}
 		// logout the current user
-		$this->userSession->logout();
+//		$this->userSession->logout();
 
 		$redirectUrl = $this->urlGenerator->linkToRoute('oauth2.page.authorize', [
 			'response_type' => $response_type,

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -137,6 +137,9 @@ class SettingsController extends Controller {
 		}
 		$client->setTrusted($trusted);
 
+		$invalidateOnLogout = $this->request->getParam('invalidate_on_logout', null) !== null;
+		$client->setInvalidateOnLogout($invalidateOnLogout);
+
 		$this->clientMapper->insert($client);
 		$this->logger->info('The client "' . $client->getName() . '" has been added.', ['app' => $this->appName]);
 

--- a/lib/Db/Client.php
+++ b/lib/Db/Client.php
@@ -33,6 +33,7 @@ use OCP\AppFramework\Db\Entity;
  * @method void setName(string $name)
  * @method boolean getAllowSubdomains()
  * @method boolean getTrusted()
+ * @method boolean getInvalidateOnLogout()
  */
 class Client extends Entity {
 	protected $identifier;
@@ -41,6 +42,7 @@ class Client extends Entity {
 	protected $name;
 	protected $allowSubdomains;
 	protected $trusted;
+	protected $invalidateOnLogout;
 
 	/**
 	 * Client constructor.
@@ -53,6 +55,7 @@ class Client extends Entity {
 		$this->addType('name', 'string');
 		$this->addType('allow_subdomains', 'boolean');
 		$this->addType('trusted', 'boolean');
+		$this->addType('invalidateOnLogout', 'boolean');
 	}
 
 	public function setAllowSubdomains(bool $value): void {
@@ -68,6 +71,14 @@ class Client extends Entity {
 			$this->setter('trusted', [$value ? 1 : 0]);
 		} else {
 			$this->setter('trusted', [$value]);
+		}
+	}
+
+	public function setInvalidateOnLogout(bool $value): void {
+		if (\OC::$server->getDatabaseConnection()->getDatabasePlatform() instanceof OraclePlatform) {
+			$this->setter('invalidateOnLogout', [$value ? 1 : 0]);
+		} else {
+			$this->setter('invalidateOnLogout', [$value]);
 		}
 	}
 }

--- a/lib/Db/ClientMapper.php
+++ b/lib/Db/ClientMapper.php
@@ -124,4 +124,15 @@ class ClientMapper extends Mapper {
 		$stmt = $this->execute($sql, []);
 		$stmt->closeCursor();
 	}
+
+	/**
+	 * Selects clients whose tokens should be invalidated on logout.
+	 *
+	 * @return Entity[] The client entities.
+	 */
+	public function findInvalidateOnLogout() {
+		$sql = 'SELECT * FROM `' . $this->tableName . '` '
+			. 'WHERE `invalidate_on_logout` = ?';
+		return $this->findEntities($sql, [1], null, null);
+	}
 }

--- a/templates/client.part.php
+++ b/templates/client.part.php
@@ -18,6 +18,11 @@
 	<?php else: ?>
 		<td></td>
 	<?php endif; ?>
+	<?php if ($client->getInvalidateOnLogout()): ?>
+		<td class="icon-32 icon-checkmark"></td>
+	<?php else: ?>
+		<td></td>
+	<?php endif; ?>
 	<td>
 		<button type="button" class="button icon-delete" data-id="<?php p($client->getId()) ?>"></button>
 	</td>

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -47,6 +47,7 @@ if (!empty($_['clients'])) {
 				<th id="headerSecret" scope="col"><?php p($l->t('Secret')); ?></th>
 				<th id="headerSubdomains" scope="col"><?php p($l->t('Subdomains allowed')); ?></th>
 				<th id="headerTrusted" scope="col"><?php p($l->t('Trusted client')); ?></th>
+				<th id="headerInvalidateOnLogout" scope="col"><?php p($l->t('Invalidate on logout')); ?></th>
 				<th id="headerRemove">&nbsp;</th>
 			</tr>
 		</thead>
@@ -67,6 +68,8 @@ if (!empty($_['clients'])) {
 		<label for="allow_subdomains"><?php p($l->t('Allow subdomains'));?></label>
 		<input name="trusted" id="trusted" type="checkbox" class="checkbox" value="1"/>
 		<label for="trusted"><?php p($l->t('Trusted client'));?></label>
+		<input name="invalidate_on_logout" id="invalidateOnLogout" type="checkbox" class="checkbox" value="1"/>
+		<label for="invalidateOnLogout"><?php p($l->t('Invalidate on logout'));?></label>
 	</form>
 	<button id="oauth2_submit" type="button" class="button"><?php p($l->t('Add')); ?></button>
 	<span id="oauth2_save_msg"></span>


### PR DESCRIPTION
The idea is to have a setting per client that determines if all tokens for this client should be removed on user logout. Hence we implemented a new flag `invalidateOnLogout` that can be set per client. Then we hook onto the `logout` event where we simply remove all the tokens for this user which are connected to a client which has `invalidateOnLogout` set to `true`.

## Motivation/Context

Let's say you have Web running via oauth and log out of oC10. Currently, you will still be logged in in Web because the tokens are not being invalidated.

Fixes https://github.com/owncloud/web/issues/7018