### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased] ....
 
 
+## [0.7.1] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+
+## [0.7.0] - 2026-06-29
+
+### Changed
+- ownCloud 11 compatible release (oc 11.0.0-rc1).
+
 ## [0.6.1] - 2023-08-31
 
 ### FIXED
@@ -157,7 +167,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Verify Bearer token even if the session is still valid - [#53](https://github.com/owncloud/oauth2/pull/53)
 - Use displayname on switch user screen - [#90](https://github.com/owncloud/oauth2/pull/90)
 
-[Unreleased]: https://github.com/owncloud/oauth2/compare/v0.6.1...master
+[Unreleased]: https://github.com/owncloud/oauth2/compare/v0.7.1..master
+[0.7.1]: https://github.com/owncloud/oauth2/compare/v0.7.0..v0.7.1
+[0.7.0]: https://github.com/owncloud/oauth2/compare/v0.6.1..v0.7.0
 [0.6.1]: https://github.com/owncloud/oauth2/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/owncloud/oauth2/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/owncloud/oauth2/compare/v0.5.2...v0.5.3

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,7 +24,7 @@ When using OAuth2 a unique access token is generated for each device or third pa
 - [OAuth protocol web page](https://oauth.net/2/)</description>
     <licence>AGPL</licence>
     <author>Project Seminar "sciebo@Learnweb" of the University of Münster, Thomas Müller</author>
-    <version>0.7.0</version>
+    <version>0.7.1</version>
     <namespace>OAuth2</namespace>
     <category>security</category>
     <website>https://github.com/owncloud/oauth2</website>


### PR DESCRIPTION
Patch-level version bump (0.7.0 -> 0.7.1) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.